### PR TITLE
feat(oauth): make OAuth scopes configurable via SSO_SCOPES env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,10 +19,11 @@ SSO_CLIENT_ID=sso_client_id
 SSO_CLIENT_SECRET=sso_client_secret
 SSO_ISSUER_HOST=sso_issuer_host
 SSO_CALLBACK_URL=http://localhost:8080/auth/callback/oidc
+SSO_SCOPES=email,openid,profile,session:role-any
 
 #  This is required only if ENABLE_AUTH is True
-POSTGRES_HOST=localhost
+POSTGRES_HOST=postgres_host
 POSTGRES_PORT=5432
-POSTGRES_DB=postgres
-POSTGRES_USER=postgres
-POSTGRES_PASSWORD=postgres
+POSTGRES_DB=postgres_db
+POSTGRES_USER=postgres_user
+POSTGRES_PASSWORD=postgres_password

--- a/.env.example
+++ b/.env.example
@@ -14,24 +14,12 @@ COMPATIBLE_WITH_CURSOR=True
 # Python Logging
 PYTHON_LOG_LEVEL=INFO
 
-<<<<<<< oauth-scope-fix
 # This is required only if ENABLE_AUTH is True
 SSO_CLIENT_ID=sso_client_id
 SSO_CLIENT_SECRET=sso_client_secret
 SSO_ISSUER_HOST=sso_issuer_host
 SSO_CALLBACK_URL=http://localhost:8080/auth/callback/oidc
 SSO_SCOPES=email,openid,profile,session:role-any
-
-#  This is required only if ENABLE_AUTH is True
-POSTGRES_HOST=postgres_host
-=======
-# --- OAuth / SSO (required only if ENABLE_AUTH=True) ---
-# Register a client in your OIDC provider and fill in these values.
-# See docs/authentication.md for setup instructions.
-SSO_CLIENT_ID=your-client-id
-SSO_CLIENT_SECRET=your-client-secret
-SSO_CALLBACK_URL=http://localhost:5001/auth/callback/oidc
-
 # Get these from your provider's .well-known/openid-configuration endpoint
 SSO_AUTHORIZATION_URL=https://sso.example.com/realms/myrealm/protocol/openid-connect/auth
 SSO_TOKEN_URL=https://sso.example.com/realms/myrealm/protocol/openid-connect/token
@@ -39,7 +27,6 @@ SSO_INTROSPECTION_URL=https://sso.example.com/realms/myrealm/protocol/openid-con
 
 # --- PostgreSQL (required only if ENABLE_AUTH=True, for token storage) ---
 POSTGRES_HOST=localhost
->>>>>>> main
 POSTGRES_PORT=5432
 POSTGRES_DB=postgres_db
 POSTGRES_USER=postgres_user

--- a/template_mcp_server/src/oauth/handler.py
+++ b/template_mcp_server/src/oauth/handler.py
@@ -18,7 +18,11 @@ from template_mcp_server.utils.pylogger import get_python_logger
 
 logger = get_python_logger()
 
-SCOPE = ["email", "openid", "profile", "session:role-any"]
+
+def _get_scope() -> list:
+    """Resolve OAuth scope from settings.SSO_SCOPES (comma-separated)."""
+    raw = settings.SSO_SCOPES or ""
+    return [s.strip() for s in raw.split(",") if s.strip()]
 
 
 class OAuth2Handler:
@@ -29,7 +33,7 @@ class OAuth2Handler:
         """Create an OAuth2 session with the specified state."""
         return OAuth2Session(
             settings.SSO_CLIENT_ID,
-            scope=SCOPE,
+            scope=_get_scope(),
             redirect_uri=settings.SSO_CALLBACK_URL,
             state=state,
         )

--- a/template_mcp_server/src/oauth/handler.py
+++ b/template_mcp_server/src/oauth/handler.py
@@ -19,12 +19,6 @@ from template_mcp_server.utils.pylogger import get_python_logger
 logger = get_python_logger()
 
 
-def _get_scope() -> list:
-    """Resolve OAuth scope from settings.SSO_SCOPES (comma-separated)."""
-    raw = settings.SSO_SCOPES or ""
-    return [s.strip() for s in raw.split(",") if s.strip()]
-
-
 class OAuth2Handler:
     """OAuth2 handler class for managing OAuth authentication flows."""
 
@@ -33,7 +27,7 @@ class OAuth2Handler:
         """Create an OAuth2 session with the specified state."""
         return OAuth2Session(
             settings.SSO_CLIENT_ID,
-            scope=_get_scope(),
+            scope=settings.oauth_scopes,
             redirect_uri=settings.SSO_CALLBACK_URL,
             state=state,
         )

--- a/template_mcp_server/src/settings.py
+++ b/template_mcp_server/src/settings.py
@@ -1,5 +1,6 @@
 """Settings for the Template MCP Server."""
 
+from functools import cached_property
 from typing import List, Optional
 
 from dotenv import load_dotenv
@@ -17,6 +18,12 @@ try:
 except Exception as e:
     # Log error but don't fail - environment variables might be set directly
     logger.warning(f"Could not load .env file: {e}")
+
+
+def parse_sso_scopes(sso_scopes: str) -> list[str]:
+    """Parse comma-separated SSO_SCOPES into a list of non-empty scope strings."""
+    raw = sso_scopes or ""
+    return [s.strip() for s in raw.split(",") if s.strip()]
 
 
 class Settings(BaseSettings):
@@ -167,7 +174,10 @@ class Settings(BaseSettings):
         default="email,openid,profile,session:role-any",
         json_schema_extra={
             "env": "SSO_SCOPES",
-            "description": "Comma-separated OAuth scopes to request (e.g. email,openid,profile for Google)",
+            "description": (
+                "Comma-separated OAuth scopes to request (e.g. email,openid,profile for Google). "
+                "When ENABLE_AUTH is True, at least one non-empty scope is required."
+            ),
             "example": "email,openid,profile",
         },
     )
@@ -286,6 +296,11 @@ class Settings(BaseSettings):
         },
     )
 
+    @cached_property
+    def oauth_scopes(self) -> list[str]:
+        """OAuth scopes derived from SSO_SCOPES (computed once per Settings instance)."""
+        return parse_sso_scopes(self.SSO_SCOPES)
+
 
 def validate_config(settings: Settings) -> None:
     """Validate configuration settings.
@@ -317,6 +332,12 @@ def validate_config(settings: Settings) -> None:
     if settings.MCP_TRANSPORT_PROTOCOL not in valid_transport_protocols:
         raise ValueError(
             f"MCP_TRANSPORT_PROTOCOL must be one of {valid_transport_protocols}, got {settings.MCP_TRANSPORT_PROTOCOL}"
+        )
+
+    if settings.ENABLE_AUTH and not parse_sso_scopes(settings.SSO_SCOPES):
+        raise ValueError(
+            'SSO_SCOPES must contain at least one OAuth scope when ENABLE_AUTH is True '
+            '(comma-separated, e.g. "email,openid,profile").'
         )
 
 

--- a/template_mcp_server/src/settings.py
+++ b/template_mcp_server/src/settings.py
@@ -163,6 +163,14 @@ class Settings(BaseSettings):
             "description": "SSO token introspection endpoint URL",
         },
     )
+    SSO_SCOPES: str = Field(
+        default="email,openid,profile,session:role-any",
+        json_schema_extra={
+            "env": "SSO_SCOPES",
+            "description": "Comma-separated OAuth scopes to request (e.g. email,openid,profile for Google)",
+            "example": "email,openid,profile",
+        },
+    )
     SESSION_SECRET: Optional[str] = Field(
         default=None,
         json_schema_extra={

--- a/template_mcp_server/src/settings.py
+++ b/template_mcp_server/src/settings.py
@@ -26,6 +26,15 @@ def parse_sso_scopes(sso_scopes: str) -> list[str]:
     return [s.strip() for s in raw.split(",") if s.strip()]
 
 
+def validate_sso_scopes(enable_auth: bool, sso_scopes: str) -> None:
+    """Validate SSO_SCOPES according to auth mode."""
+    if enable_auth and not parse_sso_scopes(sso_scopes):
+        raise ValueError(
+            "SSO_SCOPES must contain at least one OAuth scope when ENABLE_AUTH is True "
+            '(comma-separated, e.g. "email,openid,profile").'
+        )
+
+
 class Settings(BaseSettings):
     """Configuration settings for the Template MCP Server.
 
@@ -299,11 +308,7 @@ class Settings(BaseSettings):
     @model_validator(mode="after")
     def validate_oauth_scopes(self) -> "Settings":
         """Validate SSO_SCOPES when auth is enabled."""
-        if self.ENABLE_AUTH and not parse_sso_scopes(self.SSO_SCOPES):
-            raise ValueError(
-                "SSO_SCOPES must contain at least one OAuth scope when ENABLE_AUTH is True "
-                '(comma-separated, e.g. "email,openid,profile").'
-            )
+        validate_sso_scopes(self.ENABLE_AUTH, self.SSO_SCOPES)
         return self
 
     @cached_property
@@ -344,11 +349,7 @@ def validate_config(settings: Settings) -> None:
             f"MCP_TRANSPORT_PROTOCOL must be one of {valid_transport_protocols}, got {settings.MCP_TRANSPORT_PROTOCOL}"
         )
 
-    if settings.ENABLE_AUTH and not parse_sso_scopes(settings.SSO_SCOPES):
-        raise ValueError(
-            "SSO_SCOPES must contain at least one OAuth scope when ENABLE_AUTH is True "
-            '(comma-separated, e.g. "email,openid,profile").'
-        )
+    validate_sso_scopes(settings.ENABLE_AUTH, settings.SSO_SCOPES)
 
 
 # Create config instance without validation (validation happens in main.py)

--- a/template_mcp_server/src/settings.py
+++ b/template_mcp_server/src/settings.py
@@ -298,7 +298,7 @@ class Settings(BaseSettings):
 
     @cached_property
     def oauth_scopes(self) -> list[str]:
-        """OAuth scopes derived from SSO_SCOPES (computed once per Settings instance)."""
+        """Oauth scopes derived from SSO_SCOPES (computed once per Settings instance)."""
         return parse_sso_scopes(self.SSO_SCOPES)
 
 
@@ -336,7 +336,7 @@ def validate_config(settings: Settings) -> None:
 
     if settings.ENABLE_AUTH and not parse_sso_scopes(settings.SSO_SCOPES):
         raise ValueError(
-            'SSO_SCOPES must contain at least one OAuth scope when ENABLE_AUTH is True '
+            "SSO_SCOPES must contain at least one OAuth scope when ENABLE_AUTH is True "
             '(comma-separated, e.g. "email,openid,profile").'
         )
 

--- a/template_mcp_server/src/settings.py
+++ b/template_mcp_server/src/settings.py
@@ -4,7 +4,7 @@ from functools import cached_property
 from typing import List, Optional
 
 from dotenv import load_dotenv
-from pydantic import Field
+from pydantic import Field, model_validator
 from pydantic_settings import BaseSettings
 
 from template_mcp_server.utils.pylogger import get_python_logger
@@ -295,6 +295,16 @@ class Settings(BaseSettings):
             "example": "true",
         },
     )
+
+    @model_validator(mode="after")
+    def validate_oauth_scopes(self) -> "Settings":
+        """Validate SSO_SCOPES when auth is enabled."""
+        if self.ENABLE_AUTH and not parse_sso_scopes(self.SSO_SCOPES):
+            raise ValueError(
+                "SSO_SCOPES must contain at least one OAuth scope when ENABLE_AUTH is True "
+                '(comma-separated, e.g. "email,openid,profile").'
+            )
+        return self
 
     @cached_property
     def oauth_scopes(self) -> list[str]:

--- a/tests/test_oauth_handler.py
+++ b/tests/test_oauth_handler.py
@@ -3,7 +3,8 @@ from unittest.mock import Mock, patch
 
 import httpx
 
-from template_mcp_server.src.oauth.handler import SCOPE, OAuth2Handler
+from template_mcp_server.src.oauth.handler import OAuth2Handler, _get_scope
+from template_mcp_server.src.settings import Settings
 
 
 class TestOAuth2Handler:
@@ -14,6 +15,8 @@ class TestOAuth2Handler:
         """Test creating OAuth session without state."""
         mock_settings.SSO_CLIENT_ID = "test_client_id"
         mock_settings.SSO_CALLBACK_URL = "http://localhost:3000/callback"
+        mock_settings.SSO_SCOPES = Settings.model_fields["SSO_SCOPES"].default
+        expected_scope = _get_scope()
 
         with patch("template_mcp_server.src.oauth.handler.OAuth2Session") as mock_oauth:
             mock_session = Mock()
@@ -23,7 +26,7 @@ class TestOAuth2Handler:
 
             mock_oauth.assert_called_once_with(
                 "test_client_id",
-                scope=SCOPE,
+                scope=expected_scope,
                 redirect_uri="http://localhost:3000/callback",
                 state=None,
             )
@@ -34,6 +37,8 @@ class TestOAuth2Handler:
         """Test creating OAuth session with state."""
         mock_settings.SSO_CLIENT_ID = "test_client_id"
         mock_settings.SSO_CALLBACK_URL = "http://localhost:3000/callback"
+        mock_settings.SSO_SCOPES = Settings.model_fields["SSO_SCOPES"].default
+        expected_scope = _get_scope()
 
         with patch("template_mcp_server.src.oauth.handler.OAuth2Session") as mock_oauth:
             mock_session = Mock()
@@ -43,7 +48,7 @@ class TestOAuth2Handler:
 
             mock_oauth.assert_called_once_with(
                 "test_client_id",
-                scope=SCOPE,
+                scope=expected_scope,
                 redirect_uri="http://localhost:3000/callback",
                 state="test_state",
             )
@@ -257,10 +262,20 @@ class TestOAuth2Handler:
         result = OAuth2Handler.verify_authorization_header("Basic token123")
         assert result is None
 
-    def test_scope_constant(self):
-        """Test SCOPE constant is correctly defined."""
-        expected_scope = ["email", "openid", "profile", "session:role-any"]
-        assert SCOPE == expected_scope
+    @patch("template_mcp_server.src.oauth.handler.settings")
+    def test_scope_default_from_settings(self, mock_settings):
+        """Test scope is parsed from settings.SSO_SCOPES (like other SSO settings)."""
+        mock_settings.SSO_SCOPES = Settings.model_fields["SSO_SCOPES"].default
+        expected = [s.strip() for s in mock_settings.SSO_SCOPES.split(",") if s.strip()]
+        assert _get_scope() == expected
+
+    @patch("template_mcp_server.src.oauth.handler.settings")
+    def test_get_scope_from_env(self, mock_settings):
+        """Test _get_scope() uses settings.SSO_SCOPES when set."""
+        mock_settings.SSO_SCOPES = "email,openid,profile"
+        assert _get_scope() == ["email", "openid", "profile"]
+        mock_settings.SSO_SCOPES = ""
+        assert _get_scope() == []
 
 
 class TestOAuth2HandlerIntegration:

--- a/tests/test_oauth_handler.py
+++ b/tests/test_oauth_handler.py
@@ -3,8 +3,8 @@ from unittest.mock import Mock, patch
 
 import httpx
 
-from template_mcp_server.src.oauth.handler import OAuth2Handler, _get_scope
-from template_mcp_server.src.settings import Settings
+from template_mcp_server.src.oauth.handler import OAuth2Handler
+from template_mcp_server.src.settings import Settings, parse_sso_scopes
 
 
 class TestOAuth2Handler:
@@ -15,8 +15,9 @@ class TestOAuth2Handler:
         """Test creating OAuth session without state."""
         mock_settings.SSO_CLIENT_ID = "test_client_id"
         mock_settings.SSO_CALLBACK_URL = "http://localhost:3000/callback"
-        mock_settings.SSO_SCOPES = Settings.model_fields["SSO_SCOPES"].default
-        expected_scope = _get_scope()
+        default_scopes = Settings.model_fields["SSO_SCOPES"].default
+        expected_scope = parse_sso_scopes(default_scopes)
+        mock_settings.oauth_scopes = expected_scope
 
         with patch("template_mcp_server.src.oauth.handler.OAuth2Session") as mock_oauth:
             mock_session = Mock()
@@ -37,8 +38,9 @@ class TestOAuth2Handler:
         """Test creating OAuth session with state."""
         mock_settings.SSO_CLIENT_ID = "test_client_id"
         mock_settings.SSO_CALLBACK_URL = "http://localhost:3000/callback"
-        mock_settings.SSO_SCOPES = Settings.model_fields["SSO_SCOPES"].default
-        expected_scope = _get_scope()
+        default_scopes = Settings.model_fields["SSO_SCOPES"].default
+        expected_scope = parse_sso_scopes(default_scopes)
+        mock_settings.oauth_scopes = expected_scope
 
         with patch("template_mcp_server.src.oauth.handler.OAuth2Session") as mock_oauth:
             mock_session = Mock()
@@ -262,21 +264,6 @@ class TestOAuth2Handler:
         result = OAuth2Handler.verify_authorization_header("Basic token123")
         assert result is None
 
-    @patch("template_mcp_server.src.oauth.handler.settings")
-    def test_scope_default_from_settings(self, mock_settings):
-        """Test scope is parsed from settings.SSO_SCOPES (like other SSO settings)."""
-        mock_settings.SSO_SCOPES = Settings.model_fields["SSO_SCOPES"].default
-        expected = [s.strip() for s in mock_settings.SSO_SCOPES.split(",") if s.strip()]
-        assert _get_scope() == expected
-
-    @patch("template_mcp_server.src.oauth.handler.settings")
-    def test_get_scope_from_env(self, mock_settings):
-        """Test _get_scope() uses settings.SSO_SCOPES when set."""
-        mock_settings.SSO_SCOPES = "email,openid,profile"
-        assert _get_scope() == ["email", "openid", "profile"]
-        mock_settings.SSO_SCOPES = ""
-        assert _get_scope() == []
-
 
 class TestOAuth2HandlerIntegration:
     """Integration tests for OAuth2Handler."""
@@ -292,6 +279,7 @@ class TestOAuth2HandlerIntegration:
         mock_settings.SSO_CLIENT_ID = "client123"
         mock_settings.SSO_CLIENT_SECRET = "secret123"
         mock_settings.SSO_CALLBACK_URL = "http://localhost:3000/callback"
+        mock_settings.oauth_scopes = ["openid", "email", "profile"]
 
         # Mock OAuth session
         mock_session = Mock()

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 
 import pytest
 
-from template_mcp_server.src.settings import Settings, validate_config
+from template_mcp_server.src.settings import Settings, parse_sso_scopes, validate_config
 
 
 class TestSettings:
@@ -87,6 +87,34 @@ class TestSettings:
         assert hasattr(settings, "MCP_TRANSPORT_PROTOCOL")
         assert hasattr(settings, "PYTHON_LOG_LEVEL")
 
+    def test_parse_sso_scopes(self):
+        """Comma-separated scopes strip whitespace and skip empties."""
+        assert parse_sso_scopes("email, openid , profile") == ["email", "openid", "profile"]
+        assert parse_sso_scopes("") == []
+        assert parse_sso_scopes("  ,  , ") == []
+
+    def test_oauth_scopes_default(self):
+        """oauth_scopes matches SSO_SCOPES when set to the field default."""
+        default = Settings.model_fields["SSO_SCOPES"].default
+        with patch.dict(os.environ, {"SSO_SCOPES": default}):
+            settings = Settings()
+        assert settings.oauth_scopes == parse_sso_scopes(default)
+
+    def test_oauth_scopes_from_env(self):
+        """oauth_scopes reflects SSO_SCOPES from environment."""
+        with patch.dict(os.environ, {"SSO_SCOPES": "a,b,c"}):
+            settings = Settings()
+        assert settings.oauth_scopes == ["a", "b", "c"]
+
+    def test_oauth_scopes_cached_per_instance(self):
+        """oauth_scopes is computed once per Settings instance."""
+        default = Settings.model_fields["SSO_SCOPES"].default
+        with patch.dict(os.environ, {"SSO_SCOPES": default}):
+            settings = Settings()
+        first = settings.oauth_scopes
+        second = settings.oauth_scopes
+        assert first is second
+
 
 class TestValidateConfig:
     """Test the validate_config function."""
@@ -161,3 +189,26 @@ class TestValidateConfig:
             settings = Settings()
             settings.MCP_TRANSPORT_PROTOCOL = protocol
             validate_config(settings)  # Should not raise
+
+    def test_sso_scopes_empty_when_auth_enabled(self):
+        """Empty SSO_SCOPES fails validation when ENABLE_AUTH is True."""
+        settings = Settings()
+        settings.ENABLE_AUTH = True
+        settings.SSO_SCOPES = ""
+        with pytest.raises(ValueError, match="SSO_SCOPES must contain at least one"):
+            validate_config(settings)
+
+    def test_sso_scopes_whitespace_only_when_auth_enabled(self):
+        """Whitespace-only SSO_SCOPES fails validation when ENABLE_AUTH is True."""
+        settings = Settings()
+        settings.ENABLE_AUTH = True
+        settings.SSO_SCOPES = "  ,  ,  "
+        with pytest.raises(ValueError, match="SSO_SCOPES must contain at least one"):
+            validate_config(settings)
+
+    def test_sso_scopes_empty_when_auth_disabled(self):
+        """Empty SSO_SCOPES is allowed when ENABLE_AUTH is False."""
+        settings = Settings()
+        settings.ENABLE_AUTH = False
+        settings.SSO_SCOPES = ""
+        validate_config(settings)

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -4,6 +4,7 @@ import os
 from unittest.mock import patch
 
 import pytest
+from pydantic import ValidationError
 
 from template_mcp_server.src.settings import Settings, parse_sso_scopes, validate_config
 
@@ -118,6 +119,21 @@ class TestSettings:
         first = settings.oauth_scopes
         second = settings.oauth_scopes
         assert first is second
+
+    def test_model_validator_rejects_empty_scopes_when_auth_enabled(self):
+        """Settings init fails if auth is enabled with empty SSO_SCOPES."""
+        with patch.dict(os.environ, {"ENABLE_AUTH": "true", "SSO_SCOPES": ""}):
+            with pytest.raises(
+                ValidationError, match="SSO_SCOPES must contain at least one"
+            ):
+                Settings()
+
+    def test_model_validator_allows_empty_scopes_when_auth_disabled(self):
+        """Settings init allows empty SSO_SCOPES when auth is disabled."""
+        with patch.dict(os.environ, {"ENABLE_AUTH": "false", "SSO_SCOPES": ""}):
+            settings = Settings()
+        assert settings.ENABLE_AUTH is False
+        assert settings.oauth_scopes == []
 
 
 class TestValidateConfig:

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -89,7 +89,11 @@ class TestSettings:
 
     def test_parse_sso_scopes(self):
         """Comma-separated scopes strip whitespace and skip empties."""
-        assert parse_sso_scopes("email, openid , profile") == ["email", "openid", "profile"]
+        assert parse_sso_scopes("email, openid , profile") == [
+            "email",
+            "openid",
+            "profile",
+        ]
         assert parse_sso_scopes("") == []
         assert parse_sso_scopes("  ,  , ") == []
 


### PR DESCRIPTION
Why move scope to environment variable:
- Google OAuth rejects the scope 'session:role-any' (Error 400: invalid_scope). That scope is valid for other IdPs (e.g. Keycloak) but not for Google.
- Different OAuth providers support different scopes. Making scopes configurable allows the same server to work with Google (email,openid,profile) and other providers that support session:role-any without code changes.
- Aligns with other SSO settings (SSO_CLIENT_ID, SSO_CALLBACK_URL, etc.) so all OAuth behaviour is overridable via environment.

Changes:
- Add SSO_SCOPES to settings (comma-separated string, default unchanged).
- OAuth handler reads settings.SSO_SCOPES and parses to list; no hardcoded default in handler (single source of truth in settings).
- Document SSO_SCOPES in .env.example.
- Update tests to use Settings default and assert env override behaviour.