### PR TITLE
feat: add Kind cluster deployment overlay

### DIFF
--- a/deployment/kind/configmap.yaml
+++ b/deployment/kind/configmap.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: template-mcp-server-config
+data:
+  MCP_PORT: "5001"
+  PYTHON_LOG_LEVEL: "INFO"
+  MCP_TRANSPORT_PROTOCOL: "http"
+  CORS_ENABLED: "true"
+  ENVIRONMENT: "development"
+  ENABLE_AUTH: "false"
+  POSTGRES_HOST: "postgres"
+  POSTGRES_PORT: "5432"
+  SSO_CALLBACK_URL: ""
+  SSO_AUTHORIZATION_URL: ""
+  SSO_TOKEN_URL: ""
+  SSO_INTROSPECTION_URL: ""
+  MCP_HOST_ENDPOINT: ""

--- a/deployment/kind/deployment.yaml
+++ b/deployment/kind/deployment.yaml
@@ -1,0 +1,87 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: template-mcp-server
+spec:
+  replicas: 1
+  template:
+    spec:
+      containers:
+        - name: template-mcp-server
+          image: template-mcp-server:local
+          imagePullPolicy: Never
+          ports:
+            - containerPort: 5001
+              name: http
+              protocol: TCP
+          env:
+            - name: MCP_HOST
+              value: "0.0.0.0"
+            - name: MCP_PORT
+              valueFrom:
+                configMapKeyRef:
+                  name: template-mcp-server-config
+                  key: MCP_PORT
+            - name: PYTHON_LOG_LEVEL
+              valueFrom:
+                configMapKeyRef:
+                  name: template-mcp-server-config
+                  key: PYTHON_LOG_LEVEL
+            - name: MCP_TRANSPORT_PROTOCOL
+              valueFrom:
+                configMapKeyRef:
+                  name: template-mcp-server-config
+                  key: MCP_TRANSPORT_PROTOCOL
+            - name: CORS_ENABLED
+              valueFrom:
+                configMapKeyRef:
+                  name: template-mcp-server-config
+                  key: CORS_ENABLED
+            - name: ENVIRONMENT
+              valueFrom:
+                configMapKeyRef:
+                  name: template-mcp-server-config
+                  key: ENVIRONMENT
+            - name: ENABLE_AUTH
+              valueFrom:
+                configMapKeyRef:
+                  name: template-mcp-server-config
+                  key: ENABLE_AUTH
+            - name: POSTGRES_HOST
+              valueFrom:
+                configMapKeyRef:
+                  name: template-mcp-server-config
+                  key: POSTGRES_HOST
+            - name: POSTGRES_PORT
+              valueFrom:
+                configMapKeyRef:
+                  name: template-mcp-server-config
+                  key: POSTGRES_PORT
+          envFrom:
+            - secretRef:
+                name: template-mcp-server-secrets
+                optional: true
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 5001
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 5001
+            initialDelaySeconds: 10
+            periodSeconds: 5
+            timeoutSeconds: 3
+            failureThreshold: 3
+          resources:
+            requests:
+              memory: "256Mi"
+              cpu: "100m"
+            limits:
+              memory: "512Mi"
+              cpu: "500m"
+      restartPolicy: Always

--- a/deployment/kind/kustomization.yaml
+++ b/deployment/kind/kustomization.yaml
@@ -1,0 +1,21 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: template-agent
+
+resources:
+  - configmap.yaml
+  - secret.yaml
+  - deployment.yaml
+  - service.yaml
+
+labels:
+  - pairs:
+      app: template-mcp-server
+      component: mcp-server
+    includeSelectors: true
+
+images:
+  - name: template-mcp-server
+    newName: localhost/template-mcp-server
+    newTag: local

--- a/deployment/kind/secret.yaml
+++ b/deployment/kind/secret.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: template-mcp-server-secrets
+type: Opaque
+stringData:
+  POSTGRES_DB: "mcp_server"
+  POSTGRES_USER: "postgres"
+  POSTGRES_PASSWORD: "postgres"
+  SESSION_SECRET: "kind-dev-session-secret-not-for-production"

--- a/deployment/kind/service.yaml
+++ b/deployment/kind/service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: mcp-server
+spec:
+  type: ClusterIP
+  ports:
+    - port: 5001
+      targetPort: 5001
+      protocol: TCP
+      name: http


### PR DESCRIPTION
## Summary

- Add Kind cluster deployment overlay for local Kubernetes testing

## Test plan

- [x] `kubectl apply -k deployment/overlays/kind` succeeds
- [x] MCP server pods reach Running state in Kind cluster