### PR TITLE
fix: keep deploy openshift recipe in a single shell invocation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,7 +115,7 @@ deploy: ## Deploy to target (usage: make deploy openshift)
 		echo "Useful commands:"; \
 		echo "  View logs: oc logs -l app=template-mcp-server --tail=100"; \
 		echo "  Get route: oc get route template-mcp-server"; \
-		echo "  Check status: oc get pods,svc,route -l app=template-mcp-server"
+		echo "  Check status: oc get pods,svc,route -l app=template-mcp-server"; \
 	else \
 		echo "Usage: make deploy [openshift]"; \
 		echo "Available deployment targets: openshift"; \


### PR DESCRIPTION
The last echo before else was missing a line continuation, which split the if/else/fi block and caused a shell syntax error on make deploy openshift.

`make deploy openshift NAMESPACE=my-dev
/bin/sh: -c: line 1: syntax error: unexpected end of file
make: *** [deploy] Error 2`