### PR TITLE
Fix #45: Add MCPConnectionErrorFilter for cleaner production logs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,10 @@ COMPATIBLE_WITH_CURSOR=True
 # Python Logging
 PYTHON_LOG_LEVEL=INFO
 
+# Filter expected MCP connection errors (client disconnect, connection reset, broken pipe)
+# from ERROR-level logs to reduce noise. Set to False for debugging.
+ENABLE_MCP_CONNECTION_FILTER=True
+
 # This is required only if ENABLE_AUTH is True
 SSO_CLIENT_ID=sso_client_id
 SSO_CLIENT_SECRET=sso_client_secret

--- a/docs/development.md
+++ b/docs/development.md
@@ -86,6 +86,7 @@ The server configuration is managed through environment variables:
 | `COMPATIBLE_WITH_CURSOR`    | `False`                 | Cursor IDE OAuth2 compatibility mode                                      |
 | `CORS_ENABLED`              | `False`                 | Enable CORS middleware                                                    |
 | `CORS_ORIGINS`              | `["*"]`                 | Allowed CORS origins                                                      |
+| `ENABLE_MCP_CONNECTION_FILTER` | `True`               | Downgrade expected MCP connection errors (`client disconnected`, `connection reset`, `broken pipe`) from ERROR to DEBUG |
 
 *\* `ENABLE_AUTH` defaults to `True` in code but `False` in `.env.example`. Always copy `.env.example` to `.env`.*
 

--- a/template_mcp_server/src/api.py
+++ b/template_mcp_server/src/api.py
@@ -20,7 +20,10 @@ from template_mcp_server.src.oauth.handler import OAuth2Handler
 from template_mcp_server.src.oauth.routes import register_oauth_routes
 from template_mcp_server.src.oauth.service import OAuthService
 from template_mcp_server.src.settings import settings
-from template_mcp_server.utils.pylogger import get_python_logger
+from template_mcp_server.utils.pylogger import (
+    attach_mcp_connection_error_filter,
+    get_python_logger,
+)
 
 logger = get_python_logger(settings.PYTHON_LOG_LEVEL)
 
@@ -43,6 +46,8 @@ else:  # Default to standard HTTP (works for both "http" and "streamable-http")
 async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     """Combined lifespan handler for MCP and storage initialization."""
     global oauth_service_instance
+
+    attach_mcp_connection_error_filter(settings.ENABLE_MCP_CONNECTION_FILTER)
 
     # Initialize storage service before starting
     logger.info("Initializing storage service...")

--- a/template_mcp_server/src/settings.py
+++ b/template_mcp_server/src/settings.py
@@ -316,6 +316,14 @@ class Settings(BaseSettings):
             "example": "true",
         },
     )
+    ENABLE_MCP_CONNECTION_FILTER: bool = Field(
+        default=True,
+        json_schema_extra={
+            "env": "ENABLE_MCP_CONNECTION_FILTER",
+            "description": "Filter expected MCP connection errors (client disconnect, connection reset, broken pipe) from ERROR logs",
+            "example": True,
+        },
+    )
 
     @model_validator(mode="after")
     def validate_oauth_scopes(self) -> "Settings":

--- a/template_mcp_server/utils/pylogger.py
+++ b/template_mcp_server/utils/pylogger.py
@@ -99,6 +99,43 @@ def _configure_third_party_loggers(log_level: str) -> None:
         _setup_logger(name, log_level)
 
 
+# --- MCP Connection Error Filter ---
+
+
+class MCPConnectionErrorFilter(logging.Filter):
+    """Filter that downgrades expected MCP connection errors to DEBUG level.
+
+    Matches common client-disconnect patterns and lowers their log level
+    so that routine disconnections don't clutter production ERROR logs.
+    """
+
+    EXPECTED_PATTERNS: list[str] = [
+        "client disconnected",
+        "connection reset",
+        "broken pipe",
+    ]
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        msg = record.getMessage().lower()
+        if any(pattern in msg for pattern in self.EXPECTED_PATTERNS):
+            record.levelno = logging.DEBUG
+            record.levelname = "DEBUG"
+        return True
+
+
+def attach_mcp_connection_error_filter(enabled: bool = True) -> None:
+    """Attach MCPConnectionErrorFilter to MCP-related loggers.
+
+    Args:
+        enabled: Whether to attach the filter. When False, no-op.
+    """
+    if not enabled:
+        return
+    _filter = MCPConnectionErrorFilter()
+    for logger_name in ("mcp", "uvicorn.error", "starlette"):
+        logging.getLogger(logger_name).addFilter(_filter)
+
+
 # --- Public API ---
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -9,11 +9,11 @@ from template_mcp_server.utils.pylogger import (
     AWS_LOGGERS,
     ERROR_ONLY_LOGGERS,
     HTTP_CLIENT_LOGGERS,
-    MCPConnectionErrorFilter,
     MCP_LOGGERS,
     ML_AI_LOGGERS,
     OBSERVABILITY_LOGGERS,
     THIRD_PARTY_LOGGERS,
+    MCPConnectionErrorFilter,
     _clear_handlers,
     _configure_third_party_loggers,
     _setup_logger,
@@ -591,8 +591,13 @@ class TestMCPConnectionErrorFilter:
         # Arrange
         log_filter = MCPConnectionErrorFilter()
         record = logging.LogRecord(
-            name="test", level=logging.ERROR, pathname="", lineno=0,
-            msg="Client disconnected: connection closed", args=(), exc_info=None,
+            name="test",
+            level=logging.ERROR,
+            pathname="",
+            lineno=0,
+            msg="Client disconnected: connection closed",
+            args=(),
+            exc_info=None,
         )
 
         # Act
@@ -608,8 +613,13 @@ class TestMCPConnectionErrorFilter:
         # Arrange
         log_filter = MCPConnectionErrorFilter()
         record = logging.LogRecord(
-            name="test", level=logging.ERROR, pathname="", lineno=0,
-            msg="Connection reset by peer", args=(), exc_info=None,
+            name="test",
+            level=logging.ERROR,
+            pathname="",
+            lineno=0,
+            msg="Connection reset by peer",
+            args=(),
+            exc_info=None,
         )
 
         # Act
@@ -625,8 +635,13 @@ class TestMCPConnectionErrorFilter:
         # Arrange
         log_filter = MCPConnectionErrorFilter()
         record = logging.LogRecord(
-            name="test", level=logging.ERROR, pathname="", lineno=0,
-            msg="Broken pipe: EPIPE", args=(), exc_info=None,
+            name="test",
+            level=logging.ERROR,
+            pathname="",
+            lineno=0,
+            msg="Broken pipe: EPIPE",
+            args=(),
+            exc_info=None,
         )
 
         # Act
@@ -642,8 +657,13 @@ class TestMCPConnectionErrorFilter:
         # Arrange
         log_filter = MCPConnectionErrorFilter()
         record = logging.LogRecord(
-            name="test", level=logging.ERROR, pathname="", lineno=0,
-            msg="Internal server error", args=(), exc_info=None,
+            name="test",
+            level=logging.ERROR,
+            pathname="",
+            lineno=0,
+            msg="Internal server error",
+            args=(),
+            exc_info=None,
         )
 
         # Act
@@ -659,8 +679,13 @@ class TestMCPConnectionErrorFilter:
         # Arrange
         log_filter = MCPConnectionErrorFilter()
         record = logging.LogRecord(
-            name="test", level=logging.ERROR, pathname="", lineno=0,
-            msg="CLIENT DISCONNECTED", args=(), exc_info=None,
+            name="test",
+            level=logging.ERROR,
+            pathname="",
+            lineno=0,
+            msg="CLIENT DISCONNECTED",
+            args=(),
+            exc_info=None,
         )
 
         # Act

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,6 @@
 """Tests for the utils module."""
 
+import logging
 from unittest.mock import Mock, patch
 
 import pytest
@@ -8,6 +9,7 @@ from template_mcp_server.utils.pylogger import (
     AWS_LOGGERS,
     ERROR_ONLY_LOGGERS,
     HTTP_CLIENT_LOGGERS,
+    MCPConnectionErrorFilter,
     MCP_LOGGERS,
     ML_AI_LOGGERS,
     OBSERVABILITY_LOGGERS,
@@ -15,6 +17,7 @@ from template_mcp_server.utils.pylogger import (
     _clear_handlers,
     _configure_third_party_loggers,
     _setup_logger,
+    attach_mcp_connection_error_filter,
     force_reconfigure_all_loggers,
     get_python_logger,
     get_uvicorn_log_config,
@@ -578,3 +581,141 @@ class TestPylogger:
 
         # Assert - the flag should be True after force_reconfigure (since it calls get_python_logger)
         assert pylogger_module._LOGGING_CONFIGURED is True
+
+
+class TestMCPConnectionErrorFilter:
+    """Test the MCPConnectionErrorFilter class."""
+
+    def test_filter_downgrades_client_disconnected(self):
+        """Test that 'client disconnected' is downgraded to DEBUG."""
+        # Arrange
+        log_filter = MCPConnectionErrorFilter()
+        record = logging.LogRecord(
+            name="test", level=logging.ERROR, pathname="", lineno=0,
+            msg="Client disconnected: connection closed", args=(), exc_info=None,
+        )
+
+        # Act
+        result = log_filter.filter(record)
+
+        # Assert
+        assert result is True
+        assert record.levelno == logging.DEBUG
+        assert record.levelname == "DEBUG"
+
+    def test_filter_downgrades_connection_reset(self):
+        """Test that 'connection reset' is downgraded to DEBUG."""
+        # Arrange
+        log_filter = MCPConnectionErrorFilter()
+        record = logging.LogRecord(
+            name="test", level=logging.ERROR, pathname="", lineno=0,
+            msg="Connection reset by peer", args=(), exc_info=None,
+        )
+
+        # Act
+        result = log_filter.filter(record)
+
+        # Assert
+        assert result is True
+        assert record.levelno == logging.DEBUG
+        assert record.levelname == "DEBUG"
+
+    def test_filter_downgrades_broken_pipe(self):
+        """Test that 'broken pipe' is downgraded to DEBUG."""
+        # Arrange
+        log_filter = MCPConnectionErrorFilter()
+        record = logging.LogRecord(
+            name="test", level=logging.ERROR, pathname="", lineno=0,
+            msg="Broken pipe: EPIPE", args=(), exc_info=None,
+        )
+
+        # Act
+        result = log_filter.filter(record)
+
+        # Assert
+        assert result is True
+        assert record.levelno == logging.DEBUG
+        assert record.levelname == "DEBUG"
+
+    def test_filter_passes_unexpected_errors(self):
+        """Test that unexpected errors keep their original level."""
+        # Arrange
+        log_filter = MCPConnectionErrorFilter()
+        record = logging.LogRecord(
+            name="test", level=logging.ERROR, pathname="", lineno=0,
+            msg="Internal server error", args=(), exc_info=None,
+        )
+
+        # Act
+        result = log_filter.filter(record)
+
+        # Assert
+        assert result is True
+        assert record.levelno == logging.ERROR
+        assert record.levelname == "ERROR"
+
+    def test_filter_case_insensitive(self):
+        """Test that pattern matching is case-insensitive."""
+        # Arrange
+        log_filter = MCPConnectionErrorFilter()
+        record = logging.LogRecord(
+            name="test", level=logging.ERROR, pathname="", lineno=0,
+            msg="CLIENT DISCONNECTED", args=(), exc_info=None,
+        )
+
+        # Act
+        result = log_filter.filter(record)
+
+        # Assert
+        assert result is True
+        assert record.levelno == logging.DEBUG
+
+    def test_expected_patterns_are_defined(self):
+        """Test that EXPECTED_PATTERNS contains the required patterns."""
+        # Assert
+        assert "client disconnected" in MCPConnectionErrorFilter.EXPECTED_PATTERNS
+        assert "connection reset" in MCPConnectionErrorFilter.EXPECTED_PATTERNS
+        assert "broken pipe" in MCPConnectionErrorFilter.EXPECTED_PATTERNS
+
+
+class TestAttachMCPConnectionErrorFilter:
+    """Test the attach_mcp_connection_error_filter function."""
+
+    @patch("template_mcp_server.utils.pylogger.logging")
+    def test_attach_filter_when_enabled(self, mock_logging):
+        """Test that filter is attached to target loggers when enabled."""
+        # Arrange
+        mock_mcp_logger = Mock()
+        mock_uvicorn_logger = Mock()
+        mock_starlette_logger = Mock()
+
+        def getLogger_side_effect(name):
+            loggers = {
+                "mcp": mock_mcp_logger,
+                "uvicorn.error": mock_uvicorn_logger,
+                "starlette": mock_starlette_logger,
+            }
+            return loggers.get(name, Mock())
+
+        mock_logging.getLogger.side_effect = getLogger_side_effect
+
+        # Act
+        attach_mcp_connection_error_filter(enabled=True)
+
+        # Assert
+        assert mock_mcp_logger.addFilter.call_count == 1
+        assert mock_uvicorn_logger.addFilter.call_count == 1
+        assert mock_starlette_logger.addFilter.call_count == 1
+
+        # Verify the filter is an MCPConnectionErrorFilter
+        filter_arg = mock_mcp_logger.addFilter.call_args[0][0]
+        assert isinstance(filter_arg, MCPConnectionErrorFilter)
+
+    @patch("template_mcp_server.utils.pylogger.logging")
+    def test_no_filter_when_disabled(self, mock_logging):
+        """Test that no filter is attached when disabled."""
+        # Act
+        attach_mcp_connection_error_filter(enabled=False)
+
+        # Assert
+        mock_logging.getLogger.assert_not_called()


### PR DESCRIPTION
Fixes #45

Added `MCPConnectionErrorFilter` class (downgrades expected disconnect patterns to DEBUG) and `ENABLE_MCP_CONNECTION_FILTER` feature flag (default `True`), wired into the app lifespan, applied to `mcp`, `uvicorn.error`, and `starlette` loggers, with tests and docs.

Local test infra unavailable in CI sandbox.

---
This change was prepared with AI assistance under human direction and review.