### PR TITLE
feat: add Jinja2 template safety utilities

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,9 @@ USE_EXTERNAL_BROWSER_AUTH=False
 # Set this to True if you need to plug it into cursor
 COMPATIBLE_WITH_CURSOR=True
 
+# Jinja2 template safety for user-controlled text
+ENABLE_JINJA2_SECURITY=True
+
 # Python Logging
 PYTHON_LOG_LEVEL=INFO
 

--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ The output should be empty (or only match this README section itself).
 | `MCP_SSL_KEYFILE`           | `None`      | SSL private key file path                                            |
 | `MCP_SSL_CERTFILE`          | `None`      | SSL certificate file path                                            |
 | `ENABLE_AUTH`               | `False`*    | Enable OAuth authentication (see [Auth Guide](docs/authentication.md)) |
+| `ENABLE_JINJA2_SECURITY`    | `True`      | Enable Jinja2 delimiter validation/escaping for user-controlled text   |
 | `USE_EXTERNAL_BROWSER_AUTH` | `False`     | Browser-based OAuth for local dev                                    |
 | `PYTHON_LOG_LEVEL`          | `INFO`      | Logging level                                                        |
 

--- a/template_mcp_server/src/settings.py
+++ b/template_mcp_server/src/settings.py
@@ -134,6 +134,14 @@ class Settings(BaseSettings):
             "example": ["*"],
         },
     )
+    ENABLE_JINJA2_SECURITY: bool = Field(
+        default=True,
+        json_schema_extra={
+            "env": "ENABLE_JINJA2_SECURITY",
+            "description": "Enable Jinja2 template injection safeguards for user input",
+            "example": True,
+        },
+    )
     SSO_CLIENT_ID: str = Field(
         default="",
         json_schema_extra={

--- a/template_mcp_server/utils/jinja2_security.py
+++ b/template_mcp_server/utils/jinja2_security.py
@@ -1,0 +1,62 @@
+"""Jinja2 template-injection safeguards for user-controlled text."""
+
+from __future__ import annotations
+
+from jinja2 import Environment
+
+from template_mcp_server.src.settings import settings
+from template_mcp_server.utils.pylogger import get_python_logger
+
+logger = get_python_logger()
+
+_JINJA2_DELIMITER_REPLACEMENTS = {
+    "{{": "{ {",
+    "}}": "} }",
+    "{%": "{ %",
+    "%}": "% }",
+    "{#": "{ #",
+    "#}": "# }",
+}
+
+
+def escape_jinja2_delimiters(text: str, *, enabled: bool | None = None) -> str:
+    """Escape Jinja2 delimiter pairs in user-controlled text.
+
+    Escaping preserves the text while preventing Jinja2 from interpreting user input
+    as a template expression, statement, or comment block.
+    """
+    if not _jinja2_security_enabled(enabled):
+        return text
+
+    escaped = text
+    for delimiter, replacement in _JINJA2_DELIMITER_REPLACEMENTS.items():
+        escaped = escaped.replace(delimiter, replacement)
+    return escaped
+
+
+def validate_user_query_for_jinja2(query: str, *, enabled: bool | None = None) -> str:
+    """Validate user input before it is interpolated into a Jinja2 template."""
+    if not _jinja2_security_enabled(enabled):
+        return query
+
+    for delimiter in _JINJA2_DELIMITER_REPLACEMENTS:
+        if delimiter in query:
+            logger.warning(
+                "Potential Jinja2 template injection blocked",
+                delimiter=delimiter,
+            )
+            raise ValueError("Potential Jinja2 template injection detected")
+    return query
+
+
+def get_secure_jinja2_env(*, enabled: bool | None = None, **kwargs) -> Environment:
+    """Return a Jinja2 environment with autoescape enabled by default."""
+    if _jinja2_security_enabled(enabled):
+        kwargs.setdefault("autoescape", True)
+    return Environment(**kwargs)
+
+
+def _jinja2_security_enabled(enabled: bool | None) -> bool:
+    if enabled is not None:
+        return enabled
+    return settings.ENABLE_JINJA2_SECURITY

--- a/tests/test_jinja2_security.py
+++ b/tests/test_jinja2_security.py
@@ -1,0 +1,63 @@
+"""Tests for Jinja2 template-injection security utilities."""
+
+from unittest.mock import Mock, patch
+
+import pytest
+from jinja2 import Environment
+
+from template_mcp_server.src.settings import Settings
+from template_mcp_server.utils.jinja2_security import (
+    escape_jinja2_delimiters,
+    get_secure_jinja2_env,
+    validate_user_query_for_jinja2,
+)
+
+
+@pytest.mark.parametrize("delimiter", ["{{", "}}", "{%", "%}", "{#", "#}"])
+def test_escape_jinja2_delimiters_escapes_injection_delimiters(delimiter):
+    escaped = escape_jinja2_delimiters(f"user input {delimiter} dangerous")
+
+    assert delimiter not in escaped
+    assert "user input" in escaped
+    assert "dangerous" in escaped
+
+
+@pytest.mark.parametrize("query", ["{{ config }}", "{% for x in xs %}", "{# hidden #}"])
+def test_validate_user_query_for_jinja2_blocks_injection_patterns(query):
+    with pytest.raises(ValueError, match="Potential Jinja2 template injection"):
+        validate_user_query_for_jinja2(query)
+
+
+def test_validate_user_query_for_jinja2_logs_blocked_attempt():
+    logger = Mock()
+
+    with patch("template_mcp_server.utils.jinja2_security.logger", logger):
+        with pytest.raises(ValueError):
+            validate_user_query_for_jinja2("hello {{ user }}")
+
+    logger.warning.assert_called_once()
+
+
+def test_validate_user_query_for_jinja2_allows_plain_text():
+    assert validate_user_query_for_jinja2("plain user search text") == "plain user search text"
+
+
+def test_get_secure_jinja2_env_enables_autoescape_by_default():
+    env = get_secure_jinja2_env()
+
+    assert isinstance(env, Environment)
+    assert env.autoescape is True
+
+
+def test_jinja2_security_feature_flag_defaults_to_true():
+    settings = Settings()
+
+    assert settings.ENABLE_JINJA2_SECURITY is True
+
+
+def test_validate_user_query_for_jinja2_respects_disabled_feature_flag():
+    assert validate_user_query_for_jinja2("{{ trusted_template }}", enabled=False) == "{{ trusted_template }}"
+
+
+def test_escape_jinja2_delimiters_respects_disabled_feature_flag():
+    assert escape_jinja2_delimiters("{{ trusted_template }}", enabled=False) == "{{ trusted_template }}"


### PR DESCRIPTION
## Summary
- Add `ENABLE_JINJA2_SECURITY` (default `True`) to control template-injection safeguards.
- Add `template_mcp_server.utils.jinja2_security` helpers:
  - `escape_jinja2_delimiters(text)`
  - `validate_user_query_for_jinja2(query)`
  - `get_secure_jinja2_env()` with `autoescape=True` by default
- Log blocked delimiter-based injection attempts at warning level.
- Document the feature flag in `.env.example` and `README.md`.

## Why
This provides the Jinja2 safety utility layer requested in #50 for template code that needs to handle user-controlled input safely.

Closes #50.

## Test plan
- [x] Added regression/unit tests and confirmed RED collection failure before implementation (`ModuleNotFoundError: No module named 'template_mcp_server.utils.jinja2_security'`).
- [x] `uv run --python 3.12 python -m pytest tests/test_jinja2_security.py -q` — 15 passed
- [x] `uv run --python 3.12 python -m pytest tests/test_jinja2_security.py tests/test_settings.py tests/test_utils.py -q` — 73 passed
- [x] `uv run --python 3.12 python -m pytest tests -q` — 320 passed, 1 skipped, 1 existing warning
- [x] `uv run --python 3.12 ruff check template_mcp_server tests/test_jinja2_security.py tests/test_settings.py` — passed
- [x] `uv run --python 3.12 python -m py_compile template_mcp_server/utils/jinja2_security.py template_mcp_server/src/settings.py tests/test_jinja2_security.py`
- [x] README/.env feature flag assertion script
- [x] `git diff --check`
