### PR TITLE
feat: add graceful shutdown handling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,10 @@ USE_EXTERNAL_BROWSER_AUTH=False
 # Set this to True if you need to plug it into cursor
 COMPATIBLE_WITH_CURSOR=True
 
+# Graceful shutdown handling
+ENABLE_GRACEFUL_SHUTDOWN=True
+SHUTDOWN_TIMEOUT_SECONDS=30
+
 # Python Logging
 PYTHON_LOG_LEVEL=INFO
 

--- a/README.md
+++ b/README.md
@@ -109,6 +109,8 @@ The output should be empty (or only match this README section itself).
 | `MCP_SSL_KEYFILE`           | `None`      | SSL private key file path                                            |
 | `MCP_SSL_CERTFILE`          | `None`      | SSL certificate file path                                            |
 | `ENABLE_AUTH`               | `False`*    | Enable OAuth authentication (see [Auth Guide](docs/authentication.md)) |
+| `ENABLE_GRACEFUL_SHUTDOWN`  | `True`      | Register SIGINT/SIGTERM handlers for bounded shutdown cleanup          |
+| `SHUTDOWN_TIMEOUT_SECONDS`  | `30`        | Maximum seconds to wait for graceful shutdown cleanup                   |
 | `USE_EXTERNAL_BROWSER_AUTH` | `False`     | Browser-based OAuth for local dev                                    |
 | `PYTHON_LOG_LEVEL`          | `INFO`      | Logging level                                                        |
 

--- a/template_mcp_server/src/main.py
+++ b/template_mcp_server/src/main.py
@@ -8,6 +8,10 @@ import uvicorn
 from template_mcp_server.src.api import app
 from template_mcp_server.src.settings import settings
 from template_mcp_server.src.settings import validate_config as validate_config_func
+from template_mcp_server.utils.graceful_shutdown import (
+    GracefulShutdownManager,
+    register_graceful_shutdown,
+)
 from template_mcp_server.utils.pylogger import get_python_logger, get_uvicorn_log_config
 
 # Initialize logger
@@ -91,6 +95,16 @@ def main() -> None:
 
         logger.info(
             f"Server configured to use {settings.MCP_TRANSPORT_PROTOCOL} protocol"
+        )
+
+        shutdown_manager = GracefulShutdownManager(
+            timeout_seconds=settings.SHUTDOWN_TIMEOUT_SECONDS,
+            logger=logger,
+        )
+        register_graceful_shutdown(
+            app,
+            shutdown_manager,
+            enabled=settings.ENABLE_GRACEFUL_SHUTDOWN,
         )
 
         uvicorn_config: dict[str, Any] = {}

--- a/template_mcp_server/src/settings.py
+++ b/template_mcp_server/src/settings.py
@@ -316,6 +316,24 @@ class Settings(BaseSettings):
             "example": "true",
         },
     )
+    ENABLE_GRACEFUL_SHUTDOWN: bool = Field(
+        default=True,
+        json_schema_extra={
+            "env": "ENABLE_GRACEFUL_SHUTDOWN",
+            "description": "Register SIGINT/SIGTERM handlers for bounded cleanup",
+            "example": True,
+        },
+    )
+    SHUTDOWN_TIMEOUT_SECONDS: int = Field(
+        default=30,
+        ge=1,
+        le=300,
+        json_schema_extra={
+            "env": "SHUTDOWN_TIMEOUT_SECONDS",
+            "description": "Maximum seconds to wait for graceful shutdown cleanup",
+            "example": 30,
+        },
+    )
 
     @model_validator(mode="after")
     def validate_oauth_scopes(self) -> "Settings":

--- a/template_mcp_server/utils/graceful_shutdown.py
+++ b/template_mcp_server/utils/graceful_shutdown.py
@@ -1,0 +1,101 @@
+"""Graceful shutdown helpers for production MCP server runs."""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+import signal
+from collections.abc import Awaitable, Callable
+from types import FrameType
+from typing import Any
+
+from template_mcp_server.utils.pylogger import get_python_logger
+
+logger = get_python_logger()
+CleanupCallback = Callable[[], Awaitable[None] | None]
+
+
+class GracefulShutdownManager:
+    """Coordinate bounded cleanup work during process shutdown."""
+
+    def __init__(self, timeout_seconds: float = 30, logger: Any = logger) -> None:
+        self.timeout_seconds = timeout_seconds
+        self.logger = logger
+        self.shutdown_requested = False
+        self._cleanup_callbacks: list[CleanupCallback] = []
+
+    def add_cleanup_callback(self, callback: CleanupCallback) -> None:
+        """Register a cleanup callback to run during shutdown."""
+        self._cleanup_callbacks.append(callback)
+
+    async def shutdown(self, signum: signal.Signals | int | None = None) -> None:
+        """Run registered cleanup callbacks with timeout protection."""
+        if self.shutdown_requested:
+            self.logger.debug("Graceful shutdown already requested")
+            return
+
+        self.shutdown_requested = True
+        signal_name = _signal_name(signum)
+        self.logger.info("Graceful shutdown initiated", signal=signal_name)
+
+        try:
+            await asyncio.wait_for(self._run_cleanup_callbacks(), self.timeout_seconds)
+        except TimeoutError:
+            self.logger.warning(
+                "Graceful shutdown timed out",
+                timeout_seconds=self.timeout_seconds,
+            )
+
+    async def _run_cleanup_callbacks(self) -> None:
+        for callback in self._cleanup_callbacks:
+            try:
+                result = callback()
+                if inspect.isawaitable(result):
+                    await result
+            except Exception as exc:
+                if _is_closed_resource_error(exc):
+                    self.logger.debug("Resource already closed during shutdown", error=str(exc))
+                    continue
+                self.logger.warning("Cleanup callback failed during shutdown", error=str(exc))
+
+
+def register_graceful_shutdown(
+    app: Any,
+    manager: GracefulShutdownManager,
+    *,
+    enabled: bool = True,
+) -> GracefulShutdownManager:
+    """Register SIGINT/SIGTERM handlers and attach manager to the app state."""
+    if hasattr(app, "state"):
+        app.state.graceful_shutdown_manager = manager
+
+    if not enabled:
+        manager.logger.debug("Graceful shutdown signal handlers disabled")
+        return manager
+
+    def _handler(signum: int, _frame: FrameType | None) -> None:
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            asyncio.run(manager.shutdown(signum))
+        else:
+            loop.create_task(manager.shutdown(signum))
+
+    signal.signal(signal.SIGINT, _handler)
+    signal.signal(signal.SIGTERM, _handler)
+    manager.logger.info("Graceful shutdown signal handlers registered")
+    return manager
+
+
+def _signal_name(signum: signal.Signals | int | None) -> str | None:
+    if signum is None:
+        return None
+    try:
+        return signal.Signals(signum).name
+    except ValueError:
+        return str(signum)
+
+
+def _is_closed_resource_error(exc: Exception) -> bool:
+    text = f"{exc.__class__.__name__}: {exc}".lower()
+    return "closedresourceerror" in text or "closed resource" in text or "already closed" in text

--- a/tests/test_graceful_shutdown.py
+++ b/tests/test_graceful_shutdown.py
@@ -1,0 +1,88 @@
+"""Tests for graceful shutdown helpers."""
+
+import asyncio
+import signal
+from unittest.mock import Mock, patch
+
+import pytest
+
+from template_mcp_server.src.settings import Settings
+from template_mcp_server.utils.graceful_shutdown import (
+    GracefulShutdownManager,
+    register_graceful_shutdown,
+)
+
+
+@pytest.mark.asyncio
+async def test_shutdown_manager_runs_registered_async_cleanup_callbacks():
+    calls = []
+
+    async def cleanup_storage():
+        calls.append("storage")
+
+    manager = GracefulShutdownManager(timeout_seconds=1)
+    manager.add_cleanup_callback(cleanup_storage)
+
+    await manager.shutdown(signal.SIGTERM)
+
+    assert calls == ["storage"]
+    assert manager.shutdown_requested is True
+
+
+@pytest.mark.asyncio
+async def test_shutdown_manager_logs_closed_resource_errors_at_debug():
+    logger = Mock()
+
+    async def closed_resource_cleanup():
+        raise RuntimeError("ClosedResourceError: pool already closed")
+
+    manager = GracefulShutdownManager(timeout_seconds=1, logger=logger)
+    manager.add_cleanup_callback(closed_resource_cleanup)
+
+    await manager.shutdown(signal.SIGINT)
+
+    logger.debug.assert_called()
+
+
+@pytest.mark.asyncio
+async def test_shutdown_manager_enforces_timeout():
+    logger = Mock()
+
+    async def slow_cleanup():
+        await asyncio.sleep(0.2)
+
+    manager = GracefulShutdownManager(timeout_seconds=0.01, logger=logger)
+    manager.add_cleanup_callback(slow_cleanup)
+
+    await manager.shutdown(signal.SIGTERM)
+
+    logger.warning.assert_called()
+
+
+def test_register_graceful_shutdown_registers_sigint_sigterm_handlers():
+    app = Mock()
+    manager = GracefulShutdownManager(timeout_seconds=1)
+
+    with patch("template_mcp_server.utils.graceful_shutdown.signal.signal") as mock_signal:
+        register_graceful_shutdown(app, manager, enabled=True)
+
+    registered_signals = [call.args[0] for call in mock_signal.call_args_list]
+    assert signal.SIGINT in registered_signals
+    assert signal.SIGTERM in registered_signals
+
+
+def test_register_graceful_shutdown_respects_feature_flag():
+    app = Mock()
+    manager = GracefulShutdownManager(timeout_seconds=1)
+
+    with patch("template_mcp_server.utils.graceful_shutdown.signal.signal") as mock_signal:
+        register_graceful_shutdown(app, manager, enabled=False)
+
+    mock_signal.assert_not_called()
+
+
+def test_graceful_shutdown_settings_defaults():
+    settings = Settings()
+
+    assert settings.ENABLE_GRACEFUL_SHUTDOWN is True
+    assert settings.SHUTDOWN_TIMEOUT_SECONDS == 30


### PR DESCRIPTION
## Summary
- Add `ENABLE_GRACEFUL_SHUTDOWN` and `SHUTDOWN_TIMEOUT_SECONDS` settings.
- Add a `GracefulShutdownManager` that runs registered cleanup callbacks with timeout protection.
- Register SIGINT/SIGTERM handlers when the feature flag is enabled.
- Treat already-closed resource errors as DEBUG-level shutdown noise.
- Document the new configuration in `.env.example` and `README.md`.

## Why
Production deployments need bounded cleanup during SIGINT/SIGTERM so resource shutdown can be coordinated without noisy already-closed-resource logs.

Closes #44.

## Test plan
- [x] Added regression/unit tests and confirmed RED collection failure before implementation (`ModuleNotFoundError: No module named 'template_mcp_server.utils.graceful_shutdown'`).
- [x] `uv run --python 3.12 python -m pytest tests/test_graceful_shutdown.py -q` — 6 passed
- [x] `uv run --python 3.12 python -m pytest tests/test_main.py tests/test_settings.py tests/test_graceful_shutdown.py -q` — 44 passed, 1 existing warning
- [x] `uv run --python 3.12 python -m pytest tests -q` — 311 passed, 1 skipped, 1 existing warning
- [x] `uv run --python 3.12 ruff check template_mcp_server tests/test_graceful_shutdown.py tests/test_main.py tests/test_settings.py` — passed
- [x] `uv run --python 3.12 python -m py_compile template_mcp_server/utils/graceful_shutdown.py template_mcp_server/src/main.py template_mcp_server/src/settings.py tests/test_graceful_shutdown.py`
- [x] README/.env feature flag assertion script
- [x] `git diff --check`
