### PR TITLE
refactor: load MCP tools from YAML config-as-code

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,9 @@ COMPATIBLE_WITH_CURSOR=True
 # Python Logging
 PYTHON_LOG_LEVEL=INFO
 
+# Optional: override bundled tool YAML configs (defaults to template_mcp_server/config/tools)
+# MCP_TOOLS_CONFIG_PATH=/app/config/tools
+
 # This is required only if ENABLE_AUTH is True
 SSO_CLIENT_ID=sso_client_id
 SSO_CLIENT_SECRET=sso_client_secret

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,7 +26,7 @@ repos:
     hooks:
       - id: mypy
         args: [--ignore-missing-imports]
-        additional_dependencies: [types-requests]
+        additional_dependencies: [types-requests, types-PyYAML]
 
   - repo: https://github.com/PyCQA/pydocstyle
     rev: 6.3.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -204,14 +204,29 @@ async def my_tool(param: str) -> Dict[str, Any]:
            return {"status": "error", "error": str(e)}
    ```
 
-2. **Register in MCP server** (`template_mcp_server/src/mcp.py`):
-   ```python
-   from template_mcp_server.src.tools.your_tool import your_tool_function
-
-   def _register_mcp_tools(self) -> None:
-       # ... existing registrations ...
-       self.mcp.tool()(your_tool_function)
+2. **Add tool config** (`template_mcp_server/config/tools/your_tool.yaml`):
+   ```yaml
+   name: your_tool_function
+   enabled: true
+   handler: template_mcp_server.src.tools.your_tool:your_tool_function
+   display_name: Your Tool
+   description: What the tool does.
+   params:
+     - name: param
+       type: string
+       required: true
+   agent:
+     usecase: When to use this tool
+     instructions: Step-by-step usage
+     input_description: Expected input format
+     output_description: Expected output format
+     examples:
+       - your_tool_function("test")
+     prerequisites: none
+     related_tools: []
    ```
+
+   No changes to `mcp.py` are required — the server loads YAML configs at startup.
 
 3. **Add tests** in `tests/`:
    ```python

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -226,6 +226,8 @@ async def my_tool(param: str) -> Dict[str, Any]:
      related_tools: []
    ```
 
+   Each tool `name` must be unique across all YAML files in `template_mcp_server/config/tools/` — duplicate names are rejected by `load_tool_configs` before registration.
+
    No changes to `mcp.py` are required — the server loads YAML configs at startup.
 
 3. **Add tests** in `tests/`:

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ The template includes three example MCP tools: a multiply calculator, a code rev
 
 ## Features
 
+- **Config-as-code tools** — tool surface in YAML (`config/tools/`), behavior in Python handlers
 - **FastMCP + FastAPI** with multiple transport protocols (HTTP, SSE, streamable-HTTP)
 - **Three example tools**: multiply calculator, code review prompt, Red Hat logo
 - **Pydantic configuration** via environment variables
@@ -88,6 +89,7 @@ After creating your project, replace all references to `template-mcp-server` and
 | `.github/workflows/`    | Workflow names and paths                                                                                                      |
 | `README.md`             | Title, description, clone URL, and all badge URLs (tests, coverage, Codespaces)                                               |
 | `.env.example`          | Adjust defaults if your server uses a different port or protocol                                                              |
+| `template_mcp_server/config/tools/` | Add/rename tool YAML configs when forking                                                              |
 
 ### Verify Rename
 
@@ -111,8 +113,26 @@ The output should be empty (or only match this README section itself).
 | `ENABLE_AUTH`               | `False`*    | Enable OAuth authentication (see [Auth Guide](docs/authentication.md)) |
 | `USE_EXTERNAL_BROWSER_AUTH` | `False`     | Browser-based OAuth for local dev                                    |
 | `PYTHON_LOG_LEVEL`          | `INFO`      | Logging level                                                        |
+| `MCP_TOOLS_CONFIG_PATH`     | *(bundled)* | Directory of per-tool YAML configs (default: `template_mcp_server/config/tools`) |
 
 *\* `ENABLE_AUTH` defaults to `False` in `.env.example` but `True` in code. Always copy `.env.example` to `.env` to start with auth disabled.*
+
+## Tools config-as-code
+
+Tool **surface** (name, description, parameters, agent metadata) lives in YAML. Tool **behavior** lives in Python handlers under `src/tools/`. The server loads configs at startup — no `mcp.py` edits when adding a tool.
+
+```
+template_mcp_server/
+├── config/tools/           # One YAML file per tool
+│   ├── multiply_numbers.yaml
+│   └── ...
+└── src/
+    ├── tools_loader.py     # Load YAML → import handler → register
+    ├── tools/              # Handler implementations only
+    └── mcp.py              # Registers all tools from the loader
+```
+
+See [Architecture — Overview](docs/architecture.md#overview) for diagrams (overview, request path, tool loading, tool invocation). To add a tool, follow [docs/tutorial.md](docs/tutorial.md).
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ The output should be empty (or only match this README section itself).
 
 Tool **surface** (name, description, parameters, agent metadata) lives in YAML. Tool **behavior** lives in Python handlers under `src/tools/`. The server loads configs at startup — no `mcp.py` edits when adding a tool.
 
-```
+```text
 template_mcp_server/
 ├── config/tools/           # One YAML file per tool
 │   ├── multiply_numbers.yaml

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -120,7 +120,7 @@ sequenceDiagram
 
 ## Code Structure
 
-```
+```text
 template-mcp-server/
 ├── template_mcp_server/           # Main package directory
 │   ├── __init__.py

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,176 +1,122 @@
 # Architecture
 
-## System Architecture
+## Overview
+
+High-level view of the template MCP server. Details are broken out in the zoom-in diagrams below.
 
 ```mermaid
-graph TB
-    subgraph "External Clients"
-        A[Claude Code/LLM Client]
-        B[Custom MCP Client]
-        C[Development Tools]
+flowchart TB
+    subgraph clients [Clients]
+        Client[MCP Client]
     end
 
-    subgraph "Network Layer"
-        D[Load Balancer/Proxy]
-        E[SSL Termination]
+    subgraph server [Template MCP Server]
+        API["FastAPI (api.py)<br/>/health · /mcp"]
+        Core["MCP Core (mcp.py + FastMCP)"]
+        Loader[tools_loader.py]
+        Handlers["Python handlers (src/tools/)"]
     end
 
-    subgraph "Template MCP Server"
-        subgraph "Application Layer"
-            F[FastAPI Application<br/>api.py]
-            G[Health Check Endpoint<br/>/health]
-            H[MCP Protocol Handler<br/>/mcp]
-        end
-
-        subgraph "MCP Core"
-            I[TemplateMCPServer<br/>mcp.py]
-            J[FastMCP Instance<br/>Protocol Implementation]
-            K[Tool Registry<br/>Dynamic Registration]
-        end
-
-        subgraph "Tool Layer"
-            L[Mathematical Tools<br/>multiply_numbers]
-            M[Logo Tool<br/>get_redhat_logo]
-            N[Code Review Tool<br/>generate_code_review_prompt]
-            O[Custom Tools<br/>Extensible]
-        end
-
-        subgraph "Infrastructure Layer"
-            P[Configuration Management<br/>settings.py]
-            Q[Structured Logging<br/>pylogger.py]
-            R[Error Handling<br/>Exception Management]
-            S[Asset Management<br/>Static Resources]
-        end
-
-        subgraph "Transport Layer"
-            T[HTTP Transport]
-            U[SSE Transport]
-            V[Streamable HTTP Transport]
-        end
+    subgraph config [Configuration]
+        YAML["Tool YAML (config/tools/)"]
+        Env["Environment (.env)"]
     end
 
-    subgraph "External Dependencies"
-        W[Environment Variables<br/>.env]
-        X[SSL Certificates<br/>TLS/HTTPS]
-        Y[Static Assets<br/>Images/Files]
-        Z[Container Runtime<br/>Docker/Podman]
-    end
-
-    A --> D
-    B --> D
-    C --> D
-    D --> E
-    E --> F
-    F --> G
-    F --> H
-    H --> I
-    I --> J
-    J --> K
-    K --> L
-    K --> M
-    K --> N
-    K --> O
-    I --> P
-    I --> Q
-    I --> R
-    M --> S
-    F --> T
-    F --> U
-    F --> V
-    P --> W
-    E --> X
-    S --> Y
-    Z --> F
-
-    classDef client fill:#e3f2fd
-    classDef network fill:#f3e5f5
-    classDef application fill:#e8f5e8
-    classDef core fill:#fff3e0
-    classDef tools fill:#fce4ec
-    classDef infrastructure fill:#f1f8e9
-    classDef transport fill:#fef7e0
-    classDef external fill:#f5f5f5
-
-    class A,B,C client
-    class D,E network
-    class F,G,H application
-    class I,J,K core
-    class L,M,N,O tools
-    class P,Q,R,S infrastructure
-    class T,U,V transport
-    class W,X,Y,Z external
+    Client --> API
+    API --> Core
+    Core --> Loader
+    YAML --> Loader
+    Loader --> Handlers
+    Env -.-> Core
 ```
 
-## Control Flow
+| Box | Role |
+|-----|------|
+| **FastAPI** | HTTP entry point — health checks and MCP JSON-RPC |
+| **MCP Core** | FastMCP server instance; registers tools at startup |
+| **tools_loader.py** | Reads YAML, imports handlers, builds callables |
+| **config/tools/** | Tool surface — name, params, metadata, `handler` |
+| **src/tools/** | Tool behavior — validation, logic, return dict |
+| **.env** | Host, port, auth, secrets (not tool definitions) |
+
+## Zoom-in: Request path
+
+What happens when a client sends an HTTP request:
 
 ```mermaid
 flowchart TD
-    A[MCP Client Request] --> B{Transport Protocol?}
+    Req[Client HTTP request] --> Path{URL path?}
 
-    B -->|HTTP/Streamable-HTTP| C[FastAPI App<br/>api.py]
-    B -->|SSE| D[SSE App<br/>create_sse_app]
+    Path -->|/health| Health[Return healthy status]
+    Path -->|/mcp| Rpc[MCP JSON-RPC handler]
 
-    C --> E[Health Check?]
-    D --> E
+    Rpc --> Method{RPC method?}
 
-    E -->|/health| F[Health Endpoint<br/>Return Status]
-    E -->|/mcp| G[MCP Request Handler<br/>FastMCP Instance]
+    Method -->|tools/list| List[Return registered tool definitions]
+    Method -->|tools/call| Call[Invoke YAML-built wrapper]
 
-    G --> H{MCP Method Type?}
+    Call --> Handler[Python handler in src/tools/]
+    Handler --> Result[Structured dict response]
 
-    H -->|tools/list| I[List Available Tools<br/>Return tool definitions]
-    H -->|tools/call| J[Tool Execution Router<br/>mcp.py]
-
-    J --> K{Which Tool?}
-
-    K -->|multiply_numbers| L[Multiply Tool<br/>multiply_tool.py]
-    K -->|get_redhat_logo| M[Logo Tool<br/>redhat_logo_tool.py]
-    K -->|generate_code_review_prompt| N[Code Review Tool<br/>code_review_tool.py]
-
-    L --> O[Validate Input<br/>Check numeric types]
-    M --> P[Read Asset File<br/>Base64 encode PNG]
-    N --> Q[Generate Prompt<br/>Format code review template]
-
-    O --> R[Perform Calculation<br/>a * b]
-    P --> S[Return Image Data<br/>MIME type + base64]
-    Q --> T[Return Prompt Array<br/>Structured messages]
-
-    R --> U[Log Result<br/>Structured logging]
-    S --> U
-    T --> U
-
-    U --> V[Return Success Response<br/>JSON format]
-
-    V --> W[Send to MCP Client<br/>Complete request cycle]
-
-    F --> W
-    I --> W
-
-    X[Configuration Loading<br/>settings.py] --> Y[Environment Variables<br/>.env file]
-    Y --> Z[Pydantic Validation<br/>Type checking & defaults]
-    Z --> AA[Server Startup<br/>main.py]
-    AA --> C
-    AA --> D
-
-    BB[Error Handling] --> CC[Structured Logging<br/>pylogger.py]
-    CC --> DD[JSON Output<br/>Timestamp + Context]
-
-    O --> BB
-    P --> BB
-    Q --> BB
-
-    classDef request fill:#e3f2fd
-    classDef routing fill:#f3e5f5
-    classDef tools fill:#e8f5e8
-    classDef config fill:#fff3e0
-    classDef logging fill:#fce4ec
-
-    class A,B,E,H,K request
-    class C,D,G,J routing
-    class L,M,N,O,P,Q,R,S,T tools
-    class X,Y,Z,AA config
-    class BB,CC,DD logging
+    Health --> Done[HTTP response]
+    List --> Done
+    Result --> Done
 ```
+
+Transport selection (HTTP, SSE, streamable-HTTP) is configured via `MCP_TRANSPORT_PROTOCOL` in `api.py`. The request routing above is the same regardless of transport.
+
+## Tools config-as-code
+
+The template separates **tool surface** (YAML) from **tool behavior** (Python). This mirrors the config-as-code pattern used by `template-agent`: operational definitions live in config files; the runtime loads them at startup.
+
+| Layer | Location | Responsibility |
+|-------|----------|----------------|
+| Tool surface | `config/tools/*.yaml` | Name, description, params, agent metadata, `enabled`, `handler` |
+| Tool behavior | `src/tools/*.py` | Validation, business logic, structured return dict |
+| Loader | `src/tools_loader.py` | Validate YAML, import handler, build FastMCP callable |
+| Registration | `src/mcp.py` | Register all enabled tools with FastMCP at startup |
+| Secrets / bind | `.env` | Host, port, auth, database — unchanged |
+
+Override the config directory with `MCP_TOOLS_CONFIG_PATH` (for example, an OpenShift ConfigMap mount).
+
+### Zoom-in: Tool loading (startup)
+
+Runs once when `TemplateMCPServer` initializes. Tools with `enabled: false` are skipped.
+
+```mermaid
+flowchart TD
+    A[Server startup] --> B[mcp.py calls load_tool_registry]
+    B --> C[Read YAML files from config/tools/]
+    C --> D[Validate each file with Pydantic]
+    D --> E["Import handler (module:attr)"]
+    E --> F[Build wrapper with name, signature, docstring]
+    F --> G[Register each tool with FastMCP]
+    G --> H[Server ready — tools/list available]
+```
+
+### Zoom-in: Tool invocation (runtime)
+
+Runs on every `tools/call` request:
+
+```mermaid
+sequenceDiagram
+    participant Client as MCP Client
+    participant API as FastAPI
+    participant FastMCP as FastMCP
+    participant Wrapper as YAML wrapper
+    participant Handler as Python handler
+
+    Client->>API: POST /mcp tools/call
+    API->>FastMCP: Route request
+    FastMCP->>Wrapper: Call with typed args
+    Wrapper->>Handler: Delegate to handler
+    Handler-->>Wrapper: Dict result
+    Wrapper-->>FastMCP: Response
+    FastMCP-->>API: MCP result
+    API-->>Client: JSON-RPC response
+```
+
+**Adding a tool** requires only a handler file and a YAML config — no changes to `mcp.py`. See the [Tutorial](tutorial.md).
 
 ## Code Structure
 
@@ -178,11 +124,18 @@ flowchart TD
 template-mcp-server/
 ├── template_mcp_server/           # Main package directory
 │   ├── __init__.py
+│   ├── config/                    # Tool config-as-code (YAML)
+│   │   └── tools/                 # One YAML file per tool
+│   │       ├── multiply_numbers.yaml
+│   │       ├── generate_code_review_prompt.yaml
+│   │       ├── get_redhat_logo.yaml
+│   │       └── README.md
 │   ├── src/                       # Core source code
 │   │   ├── __init__.py
 │   │   ├── main.py               # Application entry point & startup logic
 │   │   ├── api.py                # FastAPI application & transport setup
-│   │   ├── mcp.py                # MCP server implementation & tool registration
+│   │   ├── mcp.py                # MCP server — registers tools from loader
+│   │   ├── tools_loader.py       # Load YAML configs, build FastMCP callables
 │   │   ├── settings.py           # Pydantic-based configuration management
 │   │   ├── assets/               # Static resource files
 │   │   │   └── redhat.png        # Example image asset
@@ -196,11 +149,12 @@ template-mcp-server/
 │   │   ├── storage/              # Persistent storage
 │   │   │   ├── __init__.py
 │   │   │   └── storage_service.py # PostgreSQL token storage
-│   │   └── tools/                # MCP tool implementations
+│   │   └── tools/                # MCP tool handlers (behavior only)
 │   │       ├── __init__.py
-│   │       ├── multiply_tool.py          # Mathematical operations tool
-│   │       ├── code_review_tool.py       # Code review prompt generator
-│   │       └── redhat_logo_tool.py       # Base64 image resource handler
+│   │       ├── README.md                 # Handler development guide
+│   │       ├── multiply_tool.py          # multiply_numbers handler
+│   │       ├── code_review_tool.py       # generate_code_review_prompt handler
+│   │       └── redhat_logo_tool.py       # get_redhat_logo handler
 │   └── utils/                    # Shared utilities
 │       ├── __init__.py
 │       └── pylogger.py          # Structured logging with structlog
@@ -216,7 +170,8 @@ template-mcp-server/
 │   ├── test_settings.py         # Configuration tests
 │   ├── test_storage_init.py     # Storage init tests
 │   ├── test_storage_service.py  # Storage service tests
-│   ├── test_tools.py            # Tool unit tests
+│   ├── test_tools.py            # Tool handler unit tests
+│   ├── test_tools_loader.py     # YAML loader and registry tests
 │   └── test_utils.py            # Utility tests
 ├── examples/                     # Client examples
 │   ├── fastmcp_client.py        # FastMCP client example
@@ -244,9 +199,11 @@ template-mcp-server/
 
 - **`main.py`**: Application entry point with configuration validation, error handling, and uvicorn server startup
 - **`api.py`**: FastAPI application setup with transport protocol selection (HTTP/SSE/streamable-HTTP) and health endpoints
-- **`mcp.py`**: Core MCP server class that registers tools using FastMCP decorators
+- **`mcp.py`**: Core MCP server class — loads and registers tools from YAML via `tools_loader`
+- **`tools_loader.py`**: Reads `config/tools/*.yaml`, imports handlers, builds FastMCP callables with signatures and docstrings
+- **`config/tools/`**: Per-tool YAML definitions (name, params, agent metadata, `handler`, `enabled`)
 - **`settings.py`**: Environment-based configuration using Pydantic BaseSettings with validation
-- **`tools/`**: MCP tool implementations demonstrating arithmetic, prompts, and resource access patterns
+- **`tools/`**: Python handlers — validation, business logic, structured return dicts (metadata lives in YAML)
 - **`oauth/`**: OAuth 2.0 integration — controller, handler, models, routes, service (see [Authentication Guide](authentication.md))
 - **`storage/storage_service.py`**: PostgreSQL-backed `StorageService` for persistent token and client storage. Used by the OAuth layer to store authorization codes, access tokens, refresh tokens, and registered clients. Requires PostgreSQL when auth is enabled; initialized at server startup via `oauth/service.py`
 - **`utils/pylogger.py`**: Structured JSON logging using structlog with comprehensive processors

--- a/docs/development.md
+++ b/docs/development.md
@@ -84,12 +84,42 @@ The server configuration is managed through environment variables:
 | `ENABLE_AUTH`               | `True`*                 | Enable OAuth authentication (see[Auth Guide](authentication.md))             |
 | `USE_EXTERNAL_BROWSER_AUTH` | `False`                 | Browser-based OAuth for local dev                                         |
 | `COMPATIBLE_WITH_CURSOR`    | `False`                 | Cursor IDE OAuth2 compatibility mode                                      |
+| `MCP_TOOLS_CONFIG_PATH`     | *(bundled)*             | Directory of per-tool YAML configs                                        |
 | `CORS_ENABLED`              | `False`                 | Enable CORS middleware                                                    |
 | `CORS_ORIGINS`              | `["*"]`                 | Allowed CORS origins                                                      |
 
 *\* `ENABLE_AUTH` defaults to `True` in code but `False` in `.env.example`. Always copy `.env.example` to `.env`.*
 
 See the [Authentication Guide](authentication.md) for the full list of `SSO_*` and `POSTGRES_*` variables.
+
+## Tools config-as-code
+
+Tool definitions live in `template_mcp_server/config/tools/` (one YAML file per tool). Handlers live in `template_mcp_server/src/tools/`. See [Architecture](architecture.md#tools-config-as-code) for loading and invocation diagrams.
+
+```bash
+# Optional: mount an alternate config directory (OpenShift ConfigMap, local override)
+export MCP_TOOLS_CONFIG_PATH=/path/to/tools
+```
+
+To add a tool: create a handler + YAML config, restart the server. No `mcp.py` changes required. See the [Tutorial](tutorial.md).
+
+### Connect from Cursor
+
+Add to `~/.cursor/mcp.json`:
+
+```json
+"template-mcp-server": {
+  "url": "http://localhost:5001/mcp",
+  "type": "streamableHttp"
+}
+```
+
+**Local dev tips:**
+
+- Keep `ENABLE_AUTH=False` in `.env` unless testing OAuth
+- Server must be running before enabling the MCP in Cursor (`make local`)
+- If the port is in use, set `MCP_PORT` in `.env` and update the URL in `mcp.json`
+- If Cursor shows Error with no Login button, use **Logout** to reset stale auth state, then toggle off/on
 
 ## Authentication
 
@@ -110,10 +140,19 @@ By default, `.env.example` ships with `ENABLE_AUTH=False` so you can start devel
 2. **Test MCP tools:**
 
    ```bash
-   # Test multiply tool via MCP endpoint
-   curl -X POST "http://localhost:5001/mcp" \
-        -H "Content-Type: application/json" \
-        -d '{"method": "tools/call", "params": {"name": "multiply_numbers", "arguments": {"a": 5, "b": 3}}}'
+   # Recommended: use the FastMCP client example
+   python examples/fastmcp_client.py
+
+   # Or call a tool directly (server must be running)
+   python -c "
+   import asyncio
+   from fastmcp import Client
+   async def main():
+       c = Client({'mcpServers': {'t': {'url': 'http://localhost:5001/mcp'}}})
+       async with c:
+           print(await c.call_tool('multiply_numbers', {'a': 5, 'b': 3}))
+   asyncio.run(main())
+   "
    ```
 
 ## Running Tests
@@ -191,7 +230,8 @@ The project includes a comprehensive test suite covering unit tests, integration
 
 **Test Files:**
 
-- `test_tools.py` - Tool unit tests (multiply, code review, logo)
+- `test_tools.py` - Tool handler unit tests (multiply, code review, logo)
+- `test_tools_loader.py` - YAML loader, registry, and wrapper tests
 - `test_settings.py` - Configuration and environment variable tests
 - `test_mcp.py` - MCP server initialization and tool registration tests
 - `test_api.py` - FastAPI endpoint and health check tests

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -34,29 +34,7 @@ logger = get_python_logger()
 def greet_user(
     name: str,
 ) -> Dict[str, Any]:
-    """Greet a user by name.
-
-    TOOL_NAME=greet_user
-    DISPLAY_NAME=User Greeting
-    USECASE=Generate a personalised greeting for a given user name
-    INSTRUCTIONS=1. Provide a name string, 2. Call function, 3. Receive greeting
-    INPUT_DESCRIPTION=One parameter: name (non-empty string). Examples: "Alice", "Bob"
-    OUTPUT_DESCRIPTION=Dictionary with status, operation, name, greeting, and message
-    EXAMPLES=greet_user("Alice"), greet_user("Bob")
-    PREREQUISITES=None - standalone operation
-    RELATED_TOOLS=None
-
-    CPU-bound operation - uses def for computational tasks.
-
-    Args:
-        name: The name of the person to greet.
-
-    Returns:
-        Dictionary containing the greeting result.
-
-    Raises:
-        ValueError: If name is empty or not a string.
-    """
+    """Greet a user by name. Surface metadata lives in config/tools/greet_user.yaml."""
     try:
         if not isinstance(name, str) or not name.strip():
             raise ValueError("name must be a non-empty string")
@@ -88,34 +66,45 @@ def greet_user(
 | Element | Why |
 |---|---|
 | `Dict[str, Any]` return | Every tool returns a structured dict so clients can parse results uniformly. |
-| Docstring metadata block | `TOOL_NAME`, `USECASE`, etc. are read by agents to decide *when* to call your tool. |
+| YAML config in `config/tools/` | Name, description, params, and agent metadata live in YAML — not in the handler docstring. |
 | `try / except` wrapping | Tools must never raise. Return `{"status": "error", ...}` instead. |
 | `logger` calls | Structured logging lets you trace tool invocations in production. |
 | Input validation first | Fail fast with a clear message before doing any work. |
 
 ---
 
-## Step 2: Register the Tool
+## Step 2: Add the Tool Config
 
-Open `template_mcp_server/src/mcp.py` and make two edits.
+Create `template_mcp_server/config/tools/greet_user.yaml`:
 
-**Add the import** (with the other tool imports near the top):
-
-```python
-from template_mcp_server.src.tools.greet_tool import greet_user
+```yaml
+name: greet_user
+enabled: true
+handler: template_mcp_server.src.tools.greet_tool:greet_user
+display_name: Greet User
+description: Return a greeting for the given name.
+params:
+  - name: name
+    type: string
+    required: true
+    description: Name to greet
+agent:
+  usecase: Generate a friendly greeting for a person
+  instructions: |
+    1. Provide a non-empty name string
+    2. Call the tool
+    3. Receive the greeting
+  input_description: "name (string): person to greet"
+  output_description: Dictionary with status, operation, name, greeting, and message
+  examples:
+    - greet_user("Alice")
+  prerequisites: none
+  related_tools: []
 ```
 
-**Register in `_register_mcp_tools`** (add one line):
+The server loads this file at startup and registers the handler automatically. **No changes to `mcp.py` are required.**
 
-```python
-def _register_mcp_tools(self) -> None:
-    self.mcp.tool()(multiply_numbers)
-    self.mcp.tool()(generate_code_review_prompt)
-    self.mcp.tool()(get_redhat_logo)
-    self.mcp.tool()(greet_user)          # <-- new
-```
-
-**Why `self.mcp.tool()(fn)`?** FastMCP's `tool()` returns a decorator. Calling it with the function as the argument is equivalent to `@mcp.tool()` but lets you register functions imported from other modules without modifying them.
+**Why explicit `handler:`?** The YAML declares the tool surface; Python implements behavior. The `handler` field wires them together with a clear, reviewable import path.
 
 ---
 
@@ -187,10 +176,10 @@ If using one of the [example clients](../examples/), the `greet_user` tool will 
 
 ## What You Just Learned
 
-1. **Tool file** -- one function per file in `template_mcp_server/src/tools/`.
-2. **Registration** -- two lines in `mcp.py`: one import, one `self.mcp.tool()()` call.
+1. **Tool handler** -- one function per file in `template_mcp_server/src/tools/`.
+2. **Tool config** -- one YAML file per tool in `template_mcp_server/config/tools/`.
 3. **Testing** -- class in `test_tools.py` covering success, edge, and error paths.
-4. **Convention** -- structured dict returns, metadata docstrings, input validation, logging.
+4. **Convention** -- structured dict returns, metadata in YAML, input validation, logging.
 
 ## What's Next
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -33,12 +33,12 @@ python examples/langgraph_client.py
 
 ## 🔧 **Configuration**
 
-**Update connection settings for your deployment:**
+**Update connection settings for your deployment** (match `MCP_PORT` in `.env`):
 
 ```python
 # Both files - update these URLs
-server_url = "http://localhost:5001"           # Local development
-# server_url = "http://0.0.0.0:4001"          # Custom port
+server_url = "http://localhost:5001"           # Default local development
+# server_url = "http://localhost:5010"        # If MCP_PORT overridden in .env
 # server_url = "https://your-mcp.apps.cluster.com"  # Production OpenShift
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,11 @@ dependencies = [
     "psycopg==3.2.3",
     "itsdangerous==2.2.0",
     "requests-oauthlib==2.0.0",
+    "pyyaml==6.0.2",
 ]
+
+[tool.hatch.build.targets.wheel.force-include]
+"template_mcp_server/config" = "template_mcp_server/config"
 
 [project.optional-dependencies]
 dev = [
@@ -45,6 +49,7 @@ dev = [
     "pytest-cov==6.2.1",
     "ruff==0.12.2",
     "mypy==1.16.1",
+    "types-PyYAML==6.0.12.20250516",
     "pre-commit==4.2.0",
     "httpx==0.28.1",
     "langchain-google-genai==2.1.8",

--- a/template_mcp_server/config/tools/README.md
+++ b/template_mcp_server/config/tools/README.md
@@ -1,0 +1,41 @@
+# MCP Tools Config
+
+Tool **surface** (name, description, parameters, agent metadata) lives here as YAML.
+Tool **behavior** lives in `template_mcp_server/src/tools/` as Python handlers.
+
+## Add a tool
+
+1. Create a handler in `src/tools/your_tool.py`.
+2. Add `your_tool.yaml` in this directory with an explicit `handler:` reference.
+3. Restart the server (no changes to `mcp.py` required).
+
+## Example
+
+```yaml
+name: greet_user
+enabled: true
+handler: template_mcp_server.src.tools.greet_tool:greet_user
+display_name: Greet User
+description: Return a greeting for the given name.
+params:
+  - name: name
+    type: string
+    required: true
+    description: Name to greet
+agent:
+  usecase: Generate a friendly greeting
+  instructions: |
+    1. Provide a non-empty name string
+    2. Call the tool
+    3. Receive the greeting
+  input_description: "name (string): person to greet"
+  output_description: Dictionary with status, operation, name, greeting, and message
+  examples:
+    - greet_user("Alice")
+  prerequisites: none
+  related_tools: []
+```
+
+## Override config path
+
+Set `MCP_TOOLS_CONFIG_PATH` to mount an alternate directory (for example an OpenShift ConfigMap).

--- a/template_mcp_server/config/tools/README.md
+++ b/template_mcp_server/config/tools/README.md
@@ -6,8 +6,10 @@ Tool **behavior** lives in `template_mcp_server/src/tools/` as Python handlers.
 ## Add a tool
 
 1. Create a handler in `src/tools/your_tool.py`.
-2. Add `your_tool.yaml` in this directory with an explicit `handler:` reference.
+2. Copy [`tool_template.yaml.example`](tool_template.yaml.example) to `your_tool.yaml` and edit it (the `.yaml.example` suffix keeps it out of the `*.yaml` loader glob).
 3. Restart the server (no changes to `mcp.py` required).
+
+For a full walkthrough, see [docs/tutorial.md](../../../docs/tutorial.md).
 
 ## Example
 

--- a/template_mcp_server/config/tools/generate_code_review_prompt.yaml
+++ b/template_mcp_server/config/tools/generate_code_review_prompt.yaml
@@ -1,0 +1,27 @@
+name: generate_code_review_prompt
+enabled: true
+handler: template_mcp_server.src.tools.code_review_tool:generate_code_review_prompt
+display_name: Code Review Prompt Generator
+description: Generate a structured code review prompt for external AI analysis.
+params:
+  - name: code
+    type: string
+    required: true
+    description: Source code to review
+  - name: language
+    type: string
+    required: false
+    default: python
+    description: Programming language of the code
+agent:
+  usecase: Analyze code for quality, bugs, and improvements using external AI service
+  instructions: |
+    1. Provide source code as string
+    2. Specify programming language
+    3. Receive formatted review prompt
+  input_description: 'code (string): source code to review, language (string, optional): programming language (default: "python")'
+  output_description: Dictionary with status, operation, language, formatted prompt text, and message
+  examples:
+    - 'generate_code_review_prompt("def hello(): print(''world'')", "python")'
+  prerequisites: Have source code ready for analysis
+  related_tools: []

--- a/template_mcp_server/config/tools/get_redhat_logo.yaml
+++ b/template_mcp_server/config/tools/get_redhat_logo.yaml
@@ -1,0 +1,17 @@
+name: get_redhat_logo
+enabled: true
+handler: template_mcp_server.src.tools.redhat_logo_tool:get_redhat_logo
+display_name: Get Red Hat Logo
+description: Return the Red Hat logo as a base64 encoded PNG.
+params: []
+agent:
+  usecase: Retrieve Red Hat logo for presentations, documentation, or branding
+  instructions: |
+    1. Call function (no parameters needed)
+    2. Receive base64-encoded logo data
+  input_description: No input parameters required
+  output_description: Dictionary with status, operation, logo metadata (name, description, mimeType), base64 data, size info, and message
+  examples:
+    - get_redhat_logo()
+  prerequisites: None - logo file must exist in assets directory
+  related_tools: []

--- a/template_mcp_server/config/tools/multiply_numbers.yaml
+++ b/template_mcp_server/config/tools/multiply_numbers.yaml
@@ -1,0 +1,27 @@
+name: multiply_numbers
+enabled: true
+handler: template_mcp_server.src.tools.multiply_tool:multiply_numbers
+display_name: Number Multiplication
+description: Multiply two floating-point numbers.
+params:
+  - name: a
+    type: float
+    required: true
+    description: First number to multiply
+  - name: b
+    type: float
+    required: true
+    description: Second number to multiply
+agent:
+  usecase: Multiply two (floating point) numbers together
+  instructions: |
+    1. Provide two numeric values (int or float)
+    2. Call function
+    3. Receive result
+  input_description: "Two parameters: a (number), b (number). Examples: (4, 5), (3.14, 2.0), (-1, 10)"
+  output_description: Dictionary with status, operation, input values (a, b), result, and message
+  examples:
+    - multiply_numbers(4, 5)
+    - multiply_numbers(3.14, 2.0)
+  prerequisites: None - standalone arithmetic operation
+  related_tools: []

--- a/template_mcp_server/config/tools/tool_template.yaml.example
+++ b/template_mcp_server/config/tools/tool_template.yaml.example
@@ -1,0 +1,55 @@
+# Copy this file to create a new tool config:
+#   cp tool_template.yaml.example your_tool.yaml
+#
+# Files ending in .yaml.example are NOT loaded (loader globs *.yaml only).
+# See docs/tutorial.md for the full walkthrough.
+
+# MCP tool name — must be unique across all *.yaml files in this directory.
+name: your_tool
+
+# Set false to keep the config on disk without registering at startup.
+enabled: true
+
+# Python handler as module:function (behavior lives in src/tools/).
+handler: template_mcp_server.src.tools.your_tool:your_tool
+
+# Human-friendly label shown in agent metadata.
+display_name: Your Tool
+
+# Short summary for tools/list. Use | or > for longer multiline text.
+description: |
+  One-line summary of what the tool does.
+
+  Optional extra paragraph with more detail for agents and reviewers.
+
+params:
+  # Required parameter
+  - name: input
+    type: string # str, string, float, int, integer, bool, boolean
+    required: true
+    description: Primary input for the tool
+
+  # Optional parameter with default
+  - name: format
+    type: string
+    required: false
+    default: json
+    description: Output format (optional)
+
+agent:
+  usecase: When an agent should choose this tool over others
+
+  instructions: |
+    1. First step for the agent
+    2. Second step
+    3. What to expect back
+
+  input_description: "input (string): required; format (string, optional): default json"
+  output_description: Dictionary with status, operation, result fields, and message
+
+  examples:
+    - your_tool("example")
+    - your_tool("example", format="text")
+
+  prerequisites: none
+  related_tools: [] # names of other tools in this directory, e.g. [multiply_numbers]

--- a/template_mcp_server/src/README.md
+++ b/template_mcp_server/src/README.md
@@ -25,7 +25,7 @@ src/
 ## 🚀 **Quick Start**
 
 1. **Add your handler** → `tools/your_domain_tool.py`
-2. **Add tool config** → `config/tools/your_domain_tool.yaml`
+2. **Add tool config** → `../config/tools/your_domain_tool.yaml`
 3. **Add static assets** → `assets/your_file.png`
 4. **Test** → `pytest tests/test_tools.py`
 

--- a/template_mcp_server/src/README.md
+++ b/template_mcp_server/src/README.md
@@ -24,9 +24,9 @@ src/
 
 ## 🚀 **Quick Start**
 
-1. **Add your tools** → `tools/your_domain_tool.py`
-2. **Add static assets** → `assets/your_file.png`
-3. **Register tools** → Update `mcp.py`
+1. **Add your handler** → `tools/your_domain_tool.py`
+2. **Add tool config** → `config/tools/your_domain_tool.yaml`
+3. **Add static assets** → `assets/your_file.png`
 4. **Test** → `pytest tests/test_tools.py`
 
 ## 📝 **Next Steps**

--- a/template_mcp_server/src/mcp.py
+++ b/template_mcp_server/src/mcp.py
@@ -7,17 +7,7 @@ tools for MCP clients. It uses FastMCP to register and manage MCP capabilities.
 from fastmcp import FastMCP
 
 from template_mcp_server.src.settings import settings
-
-# Import tools from the tools package
-from template_mcp_server.src.tools.code_review_tool import (
-    generate_code_review_prompt,
-)
-from template_mcp_server.src.tools.multiply_tool import (
-    multiply_numbers,
-)
-from template_mcp_server.src.tools.redhat_logo_tool import (
-    get_redhat_logo,
-)
+from template_mcp_server.src.tools_loader import load_tool_registry
 from template_mcp_server.utils.pylogger import (
     force_reconfigure_all_loggers,
     get_python_logger,
@@ -51,16 +41,11 @@ class TemplateMCPServer:
             raise
 
     def _register_mcp_tools(self) -> None:
-        """Register MCP tools for template operations (tools-first architecture).
+        """Register MCP tools from config/tools YAML definitions.
 
-        Registers all available tools with the FastMCP server instance.
-        In tools-first architecture, the server only provides tools.
-        Currently includes:
-        - multiply_numbers: Basic arithmetic operations
-        - generate_code_review_prompt: Code review prompt generation
-        - get_redhat_logo: Red Hat logo retrieval as base64
+        Tools are loaded from YAML config (see template_mcp_server/config/tools/)
+        and wired to Python handlers via explicit handler: module:attr references.
         """
-        # Register all the imported tools
-        self.mcp.tool()(multiply_numbers)
-        self.mcp.tool()(generate_code_review_prompt)
-        self.mcp.tool()(get_redhat_logo)
+        registry = load_tool_registry()
+        for tool_fn in registry.values():
+            self.mcp.tool()(tool_fn)

--- a/template_mcp_server/src/settings.py
+++ b/template_mcp_server/src/settings.py
@@ -316,6 +316,17 @@ class Settings(BaseSettings):
             "example": "true",
         },
     )
+    MCP_TOOLS_CONFIG_PATH: Optional[str] = Field(
+        default=None,
+        json_schema_extra={
+            "env": "MCP_TOOLS_CONFIG_PATH",
+            "description": (
+                "Path to directory containing per-tool YAML configs. "
+                "Defaults to template_mcp_server/config/tools when unset."
+            ),
+            "example": "/app/config/tools",
+        },
+    )
 
     @model_validator(mode="after")
     def validate_oauth_scopes(self) -> "Settings":

--- a/template_mcp_server/src/tools/README.md
+++ b/template_mcp_server/src/tools/README.md
@@ -1,44 +1,33 @@
 # MCP Tools Directory
 
-All MCP server capabilities are implemented as **tools** for maximum compatibility with AI agents.
+Handlers implement tool **behavior**. Tool **surface** (name, description, params, agent metadata) lives in [`../config/tools/`](../config/tools/).
 
-## 🔧 **Tool Development Guidelines**
+## Add a tool
 
-### **Required Tool Documentation Format**
+1. Create a handler module in this directory (one function per file).
+2. Add a YAML file in `template_mcp_server/config/tools/` with an explicit `handler:` reference.
+3. Add tests in `tests/test_tools.py`.
+4. Restart the server — **no changes to `mcp.py` required**.
 
-**CRITICAL**: All tools MUST use this structured format for agent compatibility:
+## Handler guidelines
 
 ```python
 def your_tool_function(
     input_param: str,
-    optional_param: str = "default"
+    optional_param: str = "default",
 ) -> Dict[str, Any]:
-    """
-    TOOL_NAME=your_tool_function
-    DISPLAY_NAME=Human-Readable Tool Name
-    USECASE=When/why to use this tool (specific scenarios)
-    INSTRUCTIONS=Step-by-step usage guide for agents
-    INPUT_DESCRIPTION=Expected data format with examples
-    OUTPUT_DESCRIPTION=What format you'll receive back
-    EXAMPLES=your_tool_function("example_input", "optional_value")
-    PREREQUISITES=What to do first (workflow sequence)
-    RELATED_TOOLS=Other tools to use with this one
-
-    Traditional docstring for developers goes here...
-    """
+    """Short developer note. Agent metadata lives in config/tools/your_tool.yaml."""
     try:
-        # Input validation
         if not input_param:
             raise ValueError("input_param is required")
 
-        # Your business logic here
         result = process_input(input_param, optional_param)
 
         return {
             "status": "success",
             "operation": "your_operation",
             "result": result,
-            "message": "Operation completed successfully"
+            "message": "Operation completed successfully",
         }
 
     except Exception as e:
@@ -46,40 +35,61 @@ def your_tool_function(
             "status": "error",
             "operation": "your_operation",
             "error": str(e),
-            "message": "Operation failed"
+            "message": "Operation failed",
         }
 ```
 
-### **Tool Registration**
+## YAML config example
 
-Add your tool to `../mcp.py`:
-
-```python
-# Import your tool
-from template_mcp_server.src.tools.your_tool import your_tool_function
-
-# Register in _register_mcp_tools()
-self.mcp.tool()(your_tool_function)
+```yaml
+name: your_tool_function
+enabled: true
+handler: template_mcp_server.src.tools.your_tool:your_tool_function
+display_name: Human-Readable Tool Name
+description: What the tool does.
+params:
+  - name: input_param
+    type: string
+    required: true
+    description: Primary input
+  - name: optional_param
+    type: string
+    required: false
+    default: default
+    description: Optional input
+agent:
+  usecase: When/why to use this tool
+  instructions: |
+    1. Provide input
+    2. Call the tool
+    3. Read the structured response
+  input_description: Expected data format with examples
+  output_description: What format you'll receive back
+  examples:
+    - your_tool_function("example_input")
+  prerequisites: none
+  related_tools: []
 ```
 
-## 📋 **Current Tools**
+## Current tools
 
-- `multiply_tool.py` - Basic arithmetic operations
-- `code_review_tool.py` - Generate code review prompts (converted from prompt)
-- `redhat_logo_tool.py` - Asset retrieval (converted from resource)
+| Config | Handler |
+|--------|---------|
+| `multiply_numbers.yaml` | `multiply_tool.py` |
+| `generate_code_review_prompt.yaml` | `code_review_tool.py` |
+| `get_redhat_logo.yaml` | `redhat_logo_tool.py` |
 
-## ✅ **Best Practices**
+## Best practices
 
-1. **Consistent Returns**: Always return `Dict[str, Any]` with `status` field
-2. **Error Handling**: Wrap in try/catch, return structured errors
-3. **Input Validation**: Validate all inputs before processing
-4. **Logging**: Use `from template_mcp_server.utils.pylogger import get_python_logger`
-5. **Testing**: Add tests to `../../tests/test_tools.py`
+1. **Consistent returns**: Always return `Dict[str, Any]` with a `status` field.
+2. **Error handling**: Wrap in try/except; return structured errors (do not raise to clients).
+3. **Input validation**: Validate inputs before processing.
+4. **Logging**: Use `from template_mcp_server.utils.pylogger import get_python_logger`.
+5. **Testing**: Add tests to `tests/test_tools.py` and loader tests to `tests/test_tools_loader.py`.
 
-## 🎯 **Agent-Friendly Tips**
+## Agent-friendly tips
 
-- Use **clear, action-oriented names** (`generate_report` not `report_generator`)
-- Include **concrete examples** in EXAMPLES field
-- Specify **prerequisites** for workflow guidance
-- List **related tools** to help agents chain operations
-- Keep **error messages** descriptive but concise
+- Use **clear, action-oriented names** (`generate_report` not `report_generator`).
+- Put **concrete examples** in YAML `agent.examples`.
+- Specify **prerequisites** and **related_tools** in YAML for workflow guidance.
+- Keep **error messages** descriptive but concise.

--- a/template_mcp_server/src/tools/README.md
+++ b/template_mcp_server/src/tools/README.md
@@ -1,6 +1,6 @@
 # MCP Tools Directory
 
-Handlers implement tool **behavior**. Tool **surface** (name, description, params, agent metadata) lives in [`../config/tools/`](../config/tools/).
+Handlers implement tool **behavior**. Tool **surface** (name, description, params, agent metadata) lives in [`../../config/tools/`](../../config/tools/).
 
 ## Add a tool
 

--- a/template_mcp_server/src/tools/code_review_tool.py
+++ b/template_mcp_server/src/tools/code_review_tool.py
@@ -1,8 +1,4 @@
-"""Code review tool for the Template MCP Server.
-
-This tool provides functionality to generate code review prompts
-for various programming languages as an MCP tool.
-"""
+"""Code review tool handler for the Template MCP Server."""
 
 from typing import Any, Dict
 
@@ -15,34 +11,8 @@ async def generate_code_review_prompt(
     code: str,
     language: str = "python",
 ) -> Dict[str, Any]:
-    """Generate a structured code review prompt with comprehensive metadata.
-
-    TOOL_NAME=generate_code_review_prompt
-    DISPLAY_NAME=Code Review Prompt Generator
-    USECASE=Analyze code for quality, bugs, and improvements using external AI service
-    INSTRUCTIONS=1. Provide source code as string, 2. Specify programming language, 3. Receive formatted review prompt
-    INPUT_DESCRIPTION=code (string): source code to review, language (string, optional): programming language (default: "python")
-    OUTPUT_DESCRIPTION=Dictionary with status, operation, language, formatted prompt text, and message
-    EXAMPLES=generate_code_review_prompt("def hello(): print('world')", "python")
-    PREREQUISITES=Have source code ready for analysis
-    RELATED_TOOLS=None - generates prompts for external AI analysis
-
-    I/O-bound operation - uses async def for external API calls.
-
-    Creates a structured prompt for code review that can be used with
-    language models to analyze code quality, identify issues, and suggest
-    improvements.
-
-    Args:
-        code: The source code to be reviewed.
-        language: Programming language of the code (default: "python").
-
-    Returns:
-        Dict[str, Any]: A dictionary containing the formatted code review
-            prompt and metadata.
-    """
+    """Generate a code review prompt. Metadata lives in config/tools/generate_code_review_prompt.yaml."""
     try:
-        # Validate inputs
         if not code or not isinstance(code, str):
             raise ValueError("Code must be a non-empty string")
 

--- a/template_mcp_server/src/tools/multiply_tool.py
+++ b/template_mcp_server/src/tools/multiply_tool.py
@@ -1,7 +1,4 @@
-"""Multiply tool for the Template MCP Server.
-
-This tool demonstrates basic arithmetic functionality by multiplying two numbers.
-"""
+"""Multiply tool handler for the Template MCP Server."""
 
 from typing import Any, Dict
 
@@ -10,38 +7,9 @@ from template_mcp_server.utils.pylogger import get_python_logger
 logger = get_python_logger()
 
 
-def multiply_numbers(
-    a: float,
-    b: float,
-) -> Dict[str, Any]:
-    """Multiply two numbers with comprehensive tool metadata.
-
-    TOOL_NAME=multiply_numbers
-    DISPLAY_NAME=Number Multiplication
-    USECASE=Multiply two (floating point) numbers together
-    INSTRUCTIONS=1. Provide two numeric values (int or float), 2. Call function, 3. Receive result
-    INPUT_DESCRIPTION=Two parameters: a (number), b (number). Examples: (4, 5), (3.14, 2.0), (-1, 10)
-    OUTPUT_DESCRIPTION=Dictionary with status, operation, input values (a, b), result, and message
-    EXAMPLES=multiply_numbers(4, 5), multiply_numbers(3.14, 2.0)
-    PREREQUISITES=None - standalone arithmetic operation
-    RELATED_TOOLS=None - basic math operation
-
-    CPU-bound operation - uses def for computational tasks.
-
-    This is a simple arithmetic tool that multiplies two floating-point numbers.
-
-    Args:
-        a: First number to multiply
-        b: Second number to multiply
-
-    Returns:
-        Dictionary containing the result of multiplication
-
-    Raises:
-        ValueError: If either input is not a valid number
-    """
+def multiply_numbers(a: float, b: float) -> Dict[str, Any]:
+    """Multiply two numbers. Surface metadata lives in config/tools/multiply_numbers.yaml."""
     try:
-        # Validate inputs
         if not isinstance(a, (int, float)) or not isinstance(b, (int, float)):
             raise ValueError("Both inputs must be numbers")
 

--- a/template_mcp_server/src/tools/redhat_logo_tool.py
+++ b/template_mcp_server/src/tools/redhat_logo_tool.py
@@ -1,8 +1,4 @@
-"""Red Hat logo tool for the Template MCP Server.
-
-This tool provides functionality to read and serve the Red Hat logo
-as a base64 encoded resource for MCP clients as a tool.
-"""
+"""Red Hat logo tool handler for the Template MCP Server."""
 
 import base64
 from pathlib import Path
@@ -14,39 +10,9 @@ logger = get_python_logger()
 
 
 async def get_redhat_logo() -> Dict[str, Any]:
-    """Return the Red Hat logo as a base64 encoded string.
-
-    TOOL_NAME=get_redhat_logo
-    DISPLAY_NAME=Get Red Hat Logo
-    USECASE=Retrieve Red Hat logo for presentations, documentation, or branding
-    INSTRUCTIONS=1. Call function (no parameters needed), 2. Receive base64-encoded logo data
-    INPUT_DESCRIPTION=No input parameters required
-    OUTPUT_DESCRIPTION=Dictionary with status, operation, logo metadata (name, description, mimeType), base64 data, size info, and message
-    EXAMPLES=get_redhat_logo()
-    PREREQUISITES=None - logo file must exist in assets directory
-    RELATED_TOOLS=None - standalone asset retrieval
-
-    Resource-as-tool pattern - async def for file I/O operations.
-
-    Reads the Red Hat logo PNG file from the assets directory and returns
-    it as a base64 encoded string for MCP clients to use.
-
-    Returns:
-        Dict[str, Any]: A dictionary containing the logo information with keys:
-            - status: Operation status (success/error)
-            - name: Display name for the logo
-            - description: Description of the logo
-            - mimeType: MIME type of the image (image/png)
-            - data: Base64 encoded PNG data
-            - message: Status message
-
-    Note:
-        If the logo file is not found or cannot be read, returns an error
-        response with appropriate error information.
-    """
+    """Return the Red Hat logo as base64. Metadata lives in config/tools/get_redhat_logo.yaml."""
     try:
-        # Get the path to the assets directory relative to this file
-        current_dir = Path(__file__).parent.parent  # Go up from tools to src
+        current_dir = Path(__file__).parent.parent
         assets_dir = current_dir / "assets"
         logo_path = assets_dir / "redhat.png"
 

--- a/template_mcp_server/src/tools_loader.py
+++ b/template_mcp_server/src/tools_loader.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from typing import Any, Type, cast
 
 import yaml
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 from template_mcp_server.utils.pylogger import get_python_logger
 
@@ -29,6 +29,8 @@ TYPE_ALIASES: dict[str, type] = {
 class ToolParamConfig(BaseModel):
     """Schema for a single tool parameter declared in YAML."""
 
+    model_config = ConfigDict(extra="forbid")
+
     name: str
     type: str = "str"
     required: bool = True
@@ -43,6 +45,8 @@ class ToolParamConfig(BaseModel):
 class AgentMetadata(BaseModel):
     """Agent-facing metadata for tool discovery and routing."""
 
+    model_config = ConfigDict(extra="forbid")
+
     usecase: str = ""
     instructions: str = ""
     input_description: str = ""
@@ -54,6 +58,8 @@ class AgentMetadata(BaseModel):
 
 class ToolConfig(BaseModel):
     """Full tool definition loaded from a YAML file."""
+
+    model_config = ConfigDict(extra="forbid")
 
     name: str
     enabled: bool = True

--- a/template_mcp_server/src/tools_loader.py
+++ b/template_mcp_server/src/tools_loader.py
@@ -1,0 +1,251 @@
+"""Load MCP tools from YAML config and build FastMCP-ready callables."""
+
+from __future__ import annotations
+
+import importlib
+import inspect
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any, Type, cast
+
+import yaml
+from pydantic import BaseModel, Field
+
+from template_mcp_server.utils.pylogger import get_python_logger
+
+logger = get_python_logger()
+
+TYPE_ALIASES: dict[str, type] = {
+    "str": str,
+    "string": str,
+    "float": float,
+    "int": int,
+    "integer": int,
+    "bool": bool,
+    "boolean": bool,
+}
+
+
+class ToolParamConfig(BaseModel):
+    """Schema for a single tool parameter declared in YAML."""
+
+    name: str
+    type: str = "str"
+    required: bool = True
+    default: Any = None
+    description: str = ""
+
+    def python_type(self) -> Type[Any]:
+        """Map the YAML type string to a Python type for FastMCP introspection."""
+        return TYPE_ALIASES.get(self.type.lower(), str)
+
+
+class AgentMetadata(BaseModel):
+    """Agent-facing metadata for tool discovery and routing."""
+
+    usecase: str = ""
+    instructions: str = ""
+    input_description: str = ""
+    output_description: str = ""
+    examples: list[str] = Field(default_factory=list)
+    prerequisites: str = "none"
+    related_tools: list[str] = Field(default_factory=list)
+
+
+class ToolConfig(BaseModel):
+    """Full tool definition loaded from a YAML file."""
+
+    name: str
+    enabled: bool = True
+    handler: str
+    display_name: str
+    description: str
+    params: list[ToolParamConfig] = Field(default_factory=list)
+    agent: AgentMetadata = Field(default_factory=AgentMetadata)
+
+
+def default_tools_config_path() -> Path:
+    """Return the default tools config directory bundled with the package."""
+    return Path(__file__).resolve().parent.parent / "config" / "tools"
+
+
+def resolve_tools_config_path(config_path: Path | str | None = None) -> Path:
+    """Resolve the tools config directory from override or settings."""
+    if config_path is not None:
+        return Path(config_path)
+
+    from template_mcp_server.src.settings import settings
+
+    config_override = settings.MCP_TOOLS_CONFIG_PATH
+    if isinstance(config_override, str) and config_override.strip():
+        return Path(config_override)
+
+    return default_tools_config_path()
+
+
+def load_tool_configs(config_path: Path | str | None = None) -> list[ToolConfig]:
+    """Load and validate all tool YAML files from the config directory."""
+    tools_dir = resolve_tools_config_path(config_path)
+    if not tools_dir.is_dir():
+        raise FileNotFoundError(f"Tools config directory not found: {tools_dir}")
+
+    configs: list[ToolConfig] = []
+    seen_names: set[str] = set()
+
+    for yaml_file in sorted(tools_dir.glob("*.yaml")):
+        with yaml_file.open(encoding="utf-8") as handle:
+            data = yaml.safe_load(handle)
+
+        if not data:
+            continue
+
+        config = ToolConfig.model_validate(data)
+        if config.name in seen_names:
+            raise ValueError(f"Duplicate tool name '{config.name}' in {yaml_file}")
+        seen_names.add(config.name)
+        configs.append(config)
+
+    if not configs:
+        raise ValueError(f"No tool configs found in {tools_dir}")
+
+    return configs
+
+
+def import_handler(handler: str) -> Callable[..., Any]:
+    """Import a handler callable from a module:attr string."""
+    module_path, _, attr = handler.partition(":")
+    if not module_path or not attr:
+        raise ValueError(f"Invalid handler '{handler}': expected 'module:attr'")
+
+    module = importlib.import_module(module_path)
+    fn = getattr(module, attr, None)
+    if fn is None or not callable(fn):
+        raise ValueError(f"Handler '{handler}' is not callable")
+    return fn
+
+
+def _format_related_tools(related: list[str]) -> str:
+    if not related:
+        return "None"
+    return ", ".join(related)
+
+
+def build_agent_docstring(config: ToolConfig) -> str:
+    """Build the agent metadata docstring from YAML fields."""
+    agent = config.agent
+    examples = ", ".join(agent.examples) if agent.examples else f"{config.name}()"
+    return "\n".join(
+        [
+            config.description,
+            "",
+            f"TOOL_NAME={config.name}",
+            f"DISPLAY_NAME={config.display_name}",
+            f"USECASE={agent.usecase}",
+            f"INSTRUCTIONS={agent.instructions.strip()}",
+            f"INPUT_DESCRIPTION={agent.input_description}",
+            f"OUTPUT_DESCRIPTION={agent.output_description}",
+            f"EXAMPLES={examples}",
+            f"PREREQUISITES={agent.prerequisites}",
+            f"RELATED_TOOLS={_format_related_tools(agent.related_tools)}",
+        ]
+    )
+
+
+def _build_signature(config: ToolConfig) -> inspect.Signature:
+    parameters: list[inspect.Parameter] = []
+    for param in config.params:
+        annotation = param.python_type()
+        if param.required and param.default is None:
+            default = inspect.Parameter.empty
+        else:
+            default = param.default
+        parameters.append(
+            inspect.Parameter(
+                param.name,
+                inspect.Parameter.POSITIONAL_OR_KEYWORD,
+                default=default,
+                annotation=annotation,
+            )
+        )
+    return inspect.Signature(parameters, return_annotation=dict[str, Any])
+
+
+def _bind_and_call(
+    signature: inspect.Signature, handler: Callable[..., Any], *args: Any, **kwargs: Any
+) -> Any:
+    bound = signature.bind_partial(*args, **kwargs)
+    bound.apply_defaults()
+    return handler(**bound.arguments)
+
+
+async def _bind_and_call_async(
+    signature: inspect.Signature, handler: Callable[..., Any], *args: Any, **kwargs: Any
+) -> Any:
+    bound = signature.bind_partial(*args, **kwargs)
+    bound.apply_defaults()
+    return await handler(**bound.arguments)
+
+
+def _apply_wrapper_metadata(
+    wrapper: Callable[..., Any],
+    config: ToolConfig,
+    signature: inspect.Signature,
+    docstring: str,
+    annotations: dict[str, Any],
+) -> Callable[..., Any]:
+    wrapper.__name__ = config.name
+    wrapper.__doc__ = docstring
+    wrapper.__signature__ = signature  # type: ignore[attr-defined]
+    wrapper.__annotations__ = annotations
+    return wrapper
+
+
+def build_tool_callable(
+    config: ToolConfig, handler: Callable[..., Any]
+) -> Callable[..., Any]:
+    """Wrap a handler with YAML-driven name, signature, and docstring."""
+    signature = _build_signature(config)
+    docstring = build_agent_docstring(config)
+    annotations = {param.name: param.python_type() for param in config.params}
+    annotations["return"] = dict[str, Any]
+
+    if inspect.iscoroutinefunction(handler):
+
+        async def async_wrapper(*args: Any, **kwargs: Any) -> Any:
+            return await _bind_and_call_async(signature, handler, *args, **kwargs)
+
+        return _apply_wrapper_metadata(
+            cast(Callable[..., Any], async_wrapper),
+            config,
+            signature,
+            docstring,
+            annotations,
+        )
+
+    def sync_wrapper(*args: Any, **kwargs: Any) -> Any:
+        return _bind_and_call(signature, handler, *args, **kwargs)
+
+    return _apply_wrapper_metadata(
+        sync_wrapper, config, signature, docstring, annotations
+    )
+
+
+def load_tool_registry(
+    config_path: Path | str | None = None,
+) -> dict[str, Callable[..., Any]]:
+    """Load enabled tools from config and return a name -> callable registry."""
+    registry: dict[str, Callable[..., Any]] = {}
+
+    for config in load_tool_configs(config_path):
+        if not config.enabled:
+            logger.info("Skipping disabled tool: %s", config.name)
+            continue
+
+        handler = import_handler(config.handler)
+        registry[config.name] = build_tool_callable(config, handler)
+        logger.debug("Loaded tool from config: %s", config.name)
+
+    if not registry:
+        raise ValueError("No enabled tools found in configuration")
+
+    return registry

--- a/tests/README.md
+++ b/tests/README.md
@@ -5,7 +5,8 @@ Comprehensive testing for MCP server reliability, security, and functionality.
 ## 📁 **Test Structure**
 
 - `conftest.py` - Pytest configuration and shared fixtures
-- `test_tools.py` - All MCP tools testing (core functionality)
+- `test_tools.py` - Tool handler unit tests (core functionality)
+- `test_tools_loader.py` - YAML config loader and registry tests
 - `test_mcp.py` - MCP server registration and protocol
 - `test_api.py` - FastAPI endpoints and health checks
 - `test_main.py` - Server startup and integration
@@ -64,7 +65,15 @@ def test_your_new_tool():
 
 ### **Testing Tool Registration:**
 ```python
-# tests/test_mcp.py - Verify tools are registered
+# tests/test_tools_loader.py - Verify YAML configs load correctly
+
+def test_load_tool_registry_registers_enabled_tools():
+    registry = load_tool_registry()
+    assert "your_new_tool" in registry
+```
+
+```python
+# tests/test_mcp.py - Verify server registers tools at startup
 
 def test_your_tool_registration(mcp_server):
     """Verify your tool is properly registered."""

--- a/tests/test_tools_loader.py
+++ b/tests/test_tools_loader.py
@@ -1,0 +1,177 @@
+"""Tests for the tools config loader."""
+
+import inspect
+from pathlib import Path
+
+import pytest
+
+from template_mcp_server.src import settings as settings_module
+from template_mcp_server.src.tools_loader import (
+    AgentMetadata,
+    ToolConfig,
+    build_agent_docstring,
+    build_tool_callable,
+    default_tools_config_path,
+    import_handler,
+    load_tool_configs,
+    load_tool_registry,
+    resolve_tools_config_path,
+)
+
+
+class TestToolsLoader:
+    """Test YAML-driven tool loading and registration."""
+
+    def test_default_tools_config_path_exists(self):
+        path = default_tools_config_path()
+        assert path.is_dir()
+        assert list(path.glob("*.yaml"))
+
+    def test_load_tool_configs_returns_three_tools(self):
+        configs = load_tool_configs()
+        names = {config.name for config in configs}
+        assert names == {
+            "multiply_numbers",
+            "generate_code_review_prompt",
+            "get_redhat_logo",
+        }
+
+    def test_load_tool_registry_registers_enabled_tools(self):
+        registry = load_tool_registry()
+        assert set(registry) == {
+            "multiply_numbers",
+            "generate_code_review_prompt",
+            "get_redhat_logo",
+        }
+
+    def test_registry_callable_has_yaml_docstring_metadata(self):
+        registry = load_tool_registry()
+        multiply = registry["multiply_numbers"]
+        assert multiply.__name__ == "multiply_numbers"
+        assert "TOOL_NAME=multiply_numbers" in multiply.__doc__
+        assert "DISPLAY_NAME=Number Multiplication" in multiply.__doc__
+
+    def test_registry_multiply_wrapper_delegates_to_handler(self):
+        registry = load_tool_registry()
+        result = registry["multiply_numbers"](a=4, b=5)
+        assert result["status"] == "success"
+        assert result["result"] == 20
+
+    def test_registry_signature_from_yaml(self):
+        registry = load_tool_registry()
+        sig = inspect.signature(registry["multiply_numbers"])
+        assert list(sig.parameters) == ["a", "b"]
+        assert sig.parameters["a"].annotation is float
+
+    def test_import_handler_invalid_format_raises(self):
+        with pytest.raises(ValueError, match="expected 'module:attr'"):
+            import_handler("not_a_valid_handler")
+
+    def test_import_handler_missing_callable_raises(self):
+        with pytest.raises(ValueError, match="is not callable"):
+            import_handler("template_mcp_server.src.tools.multiply_tool:missing_fn")
+
+    def test_load_tool_configs_missing_directory_raises(self, tmp_path: Path):
+        with pytest.raises(FileNotFoundError, match="Tools config directory not found"):
+            load_tool_configs(tmp_path / "missing")
+
+    def test_load_tool_configs_duplicate_names_raises(self, tmp_path: Path):
+        tools_dir = tmp_path / "tools"
+        tools_dir.mkdir()
+        (tools_dir / "one.yaml").write_text(
+            "name: dup\nenabled: true\nhandler: x:y\ndisplay_name: A\ndescription: A\n"
+        )
+        (tools_dir / "two.yaml").write_text(
+            "name: dup\nenabled: true\nhandler: x:y\ndisplay_name: B\ndescription: B\n"
+        )
+        with pytest.raises(ValueError, match="Duplicate tool name"):
+            load_tool_configs(tools_dir)
+
+    def test_load_tool_registry_skips_disabled_tools(self, tmp_path: Path):
+        tools_dir = tmp_path / "tools"
+        tools_dir.mkdir()
+        (tools_dir / "multiply_numbers.yaml").write_text(
+            (default_tools_config_path() / "multiply_numbers.yaml").read_text()
+        )
+        (tools_dir / "disabled.yaml").write_text(
+            "name: disabled_tool\nenabled: false\n"
+            "handler: template_mcp_server.src.tools.multiply_tool:multiply_numbers\n"
+            "display_name: Disabled\ndescription: Disabled tool\n"
+        )
+        registry = load_tool_registry(tools_dir)
+        assert set(registry) == {"multiply_numbers"}
+
+    def test_build_agent_docstring_includes_examples(self):
+        configs = load_tool_configs()
+        multiply = next(c for c in configs if c.name == "multiply_numbers")
+        doc = build_agent_docstring(multiply)
+        assert "multiply_numbers(4, 5)" in doc
+
+    @pytest.mark.asyncio
+    async def test_async_handler_wrapper_is_coroutine_function(self):
+        configs = load_tool_configs()
+        logo_config = next(c for c in configs if c.name == "get_redhat_logo")
+        handler = import_handler(logo_config.handler)
+        wrapped = build_tool_callable(logo_config, handler)
+        assert inspect.iscoroutinefunction(wrapped)
+
+    @pytest.mark.asyncio
+    async def test_async_handler_wrapper_delegates_to_handler(self):
+        registry = load_tool_registry()
+        result = await registry["get_redhat_logo"]()
+        assert result["status"] == "success"
+        assert result["operation"] == "get_redhat_logo"
+        assert result["mimeType"] == "image/png"
+
+    def test_resolve_tools_config_path_uses_settings_override(
+        self, tmp_path: Path, monkeypatch
+    ):
+        tools_dir = tmp_path / "custom_tools"
+        tools_dir.mkdir()
+        (tools_dir / "multiply_numbers.yaml").write_text(
+            (default_tools_config_path() / "multiply_numbers.yaml").read_text()
+        )
+        monkeypatch.setattr(
+            settings_module.settings, "MCP_TOOLS_CONFIG_PATH", str(tools_dir)
+        )
+        assert resolve_tools_config_path() == tools_dir
+
+    def test_load_tool_configs_skips_empty_yaml_files(self, tmp_path: Path):
+        tools_dir = tmp_path / "tools"
+        tools_dir.mkdir()
+        (tools_dir / "empty.yaml").write_text("")
+        (tools_dir / "multiply_numbers.yaml").write_text(
+            (default_tools_config_path() / "multiply_numbers.yaml").read_text()
+        )
+        configs = load_tool_configs(tools_dir)
+        assert len(configs) == 1
+        assert configs[0].name == "multiply_numbers"
+
+    def test_load_tool_configs_raises_when_no_valid_configs(self, tmp_path: Path):
+        tools_dir = tmp_path / "tools"
+        tools_dir.mkdir()
+        (tools_dir / "empty.yaml").write_text("")
+        with pytest.raises(ValueError, match="No tool configs found"):
+            load_tool_configs(tools_dir)
+
+    def test_load_tool_registry_raises_when_all_tools_disabled(self, tmp_path: Path):
+        tools_dir = tmp_path / "tools"
+        tools_dir.mkdir()
+        (tools_dir / "disabled.yaml").write_text(
+            "name: disabled_tool\nenabled: false\n"
+            "handler: template_mcp_server.src.tools.multiply_tool:multiply_numbers\n"
+            "display_name: Disabled\ndescription: Disabled tool\n"
+        )
+        with pytest.raises(ValueError, match="No enabled tools found"):
+            load_tool_registry(tools_dir)
+
+    def test_build_agent_docstring_formats_related_tools(self):
+        config = ToolConfig(
+            name="example",
+            handler="x:y",
+            display_name="Example",
+            description="Example tool",
+            agent=AgentMetadata(related_tools=["multiply_numbers", "get_redhat_logo"]),
+        )
+        doc = build_agent_docstring(config)
+        assert "RELATED_TOOLS=multiply_numbers, get_redhat_logo" in doc

--- a/tests/test_tools_loader.py
+++ b/tests/test_tools_loader.py
@@ -165,6 +165,18 @@ class TestToolsLoader:
         with pytest.raises(ValueError, match="No enabled tools found"):
             load_tool_registry(tools_dir)
 
+    def test_load_tool_configs_rejects_unknown_yaml_fields(self, tmp_path: Path):
+        tools_dir = tmp_path / "tools"
+        tools_dir.mkdir()
+        (tools_dir / "bad.yaml").write_text(
+            "name: bad_tool\nenabled: true\n"
+            "handler: template_mcp_server.src.tools.multiply_tool:multiply_numbers\n"
+            "display_name: Bad\ndescription: Bad tool\n"
+            "typo_field: oops\n"
+        )
+        with pytest.raises(Exception, match="extra_forbidden|Extra inputs"):
+            load_tool_configs(tools_dir)
+
     def test_build_agent_docstring_formats_related_tools(self):
         config = ToolConfig(
             name="example",


### PR DESCRIPTION
## Summary

- Introduce config-as-code for MCP tools: one YAML file per tool under `template_mcp_server/config/tools/`
- Add `tools_loader.py` to validate YAML, import handlers via explicit `handler: module:attr`, and build FastMCP callables (name, signature, docstring)
- Register tools from the loader in `mcp.py` — no hardcoded tool imports
- Strip agent metadata from handler docstrings; behavior stays in `src/tools/`
- Add `MCP_TOOLS_CONFIG_PATH` env override for mounted config dirs
- Update architecture docs with simplified overview + zoom-in diagrams (loading, invocation, request path)

## Test plan

- [x] `pytest` — 318 passed
- [x] `tests/test_tools_loader.py` — YAML load, registry, wrapper delegation, disabled tools
- [x] Existing tool handler tests unchanged
- [x] Local smoke: server starts, `tools/list` returns 3 tools with YAML metadata
- [x] Cursor MCP client connects and `multiply_numbers` works


Made with [Cursor](https://cursor.com)