### PR TITLE
refactor(deep-agent): load MCP tools from YAML config-as-code

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,10 +23,17 @@ PYTHON_LOG_LEVEL=INFO
 SSO_CLIENT_ID=your-client-id
 SSO_CLIENT_SECRET=your-client-secret
 SSO_CALLBACK_URL=http://localhost:5001/auth/callback/oidc
+# Comma-separated scopes. Use Google-friendly scopes for Google OAuth (no session:role-any).
+SSO_SCOPES=email,openid,profile,session:role-any
 
 # Get these from your provider's .well-known/openid-configuration endpoint
 SSO_AUTHORIZATION_URL=https://sso.example.com/realms/myrealm/protocol/openid-connect/auth
 SSO_TOKEN_URL=https://sso.example.com/realms/myrealm/protocol/openid-connect/token
+# rfc7662 = POST introspection (Keycloak, Auth0, Okta). tokeninfo = GET ?access_token= (Google)
+# SSO_INTROSPECTION_MODE=rfc7662
+# For Google OAuth use tokeninfo mode instead:
+# SSO_INTROSPECTION_MODE=tokeninfo
+# SSO_INTROSPECTION_URL=https://oauth2.googleapis.com/tokeninfo
 SSO_INTROSPECTION_URL=https://sso.example.com/realms/myrealm/protocol/openid-connect/token/introspect
 
 # --- Web Search (Tavily) ---

--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,9 @@ COMPATIBLE_WITH_CURSOR=True
 # Python Logging
 PYTHON_LOG_LEVEL=INFO
 
+# Optional: override bundled tool YAML directory (default: template_mcp_server/config/tools)
+# MCP_TOOLS_CONFIG_PATH=/path/to/tools
+
 # --- OAuth / SSO (required only if ENABLE_AUTH=True) ---
 # Register a client in your OIDC provider and fill in these values.
 # See docs/authentication.md for setup instructions.

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -18,7 +18,7 @@ jobs:
     name: Close stale issues and PRs
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v9
+      - uses: actions/stale@v11
         with:
           stale-issue-message: >
             This issue has been automatically marked as stale because it has not

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,7 +26,7 @@ repos:
     hooks:
       - id: mypy
         args: [--ignore-missing-imports]
-        additional_dependencies: [types-requests]
+        additional_dependencies: [types-requests, types-PyYAML]
 
   - repo: https://github.com/PyCQA/pydocstyle
     rev: 6.3.0

--- a/Makefile
+++ b/Makefile
@@ -149,7 +149,7 @@ deploy: ## Deploy to target (usage: make deploy openshift)
 		echo "Useful commands:"; \
 		echo "  View logs: oc logs -l app=template-mcp-server --tail=100"; \
 		echo "  Get route: oc get route template-mcp-server"; \
-		echo "  Check status: oc get pods,svc,route -l app=template-mcp-server"
+		echo "  Check status: oc get pods,svc,route -l app=template-mcp-server"; \
 	else \
 		echo "Usage: make deploy [openshift]"; \
 		echo "Available deployment targets: openshift"; \

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -148,6 +148,7 @@ SSO_INTROSPECTION_URL=https://sso.example.com/realms/myrealm/protocol/openid-con
 | `SSO_AUTHORIZATION_URL`     | Auth enabled  | `""`    | Provider's authorization endpoint               |
 | `SSO_TOKEN_URL`             | Auth enabled  | `""`    | Provider's token endpoint                       |
 | `SSO_INTROSPECTION_URL`     | Auth enabled  | `""`    | Provider's token introspection endpoint         |
+| `SSO_INTROSPECTION_MODE`    | Auth enabled  | `rfc7662` | Introspection strategy: `rfc7662` or `tokeninfo` |
 | `SESSION_SECRET`            | Production    | `None`  | Secret key for session middleware               |
 | `COMPATIBLE_WITH_CURSOR`    | Cursor IDE    | `False` | Enables Cursor-compatible OAuth2 flow           |
 | `POSTGRES_HOST`             | Auth enabled  | `None`  | PostgreSQL host for token storage               |
@@ -180,6 +181,23 @@ USE_EXTERNAL_BROWSER_AUTH=True   # or False for production
 ```
 
 > **Security note:** `COMPATIBLE_WITH_CURSOR=True` relaxes validation. Use it only for local development with Cursor, not in production.
+
+## Google OAuth
+
+Google does **not** expose an [RFC 7662](https://datatracker.ietf.org/doc/html/rfc7662) token introspection endpoint. Use Google's tokeninfo endpoint instead:
+
+```bash
+SSO_INTROSPECTION_MODE=tokeninfo
+SSO_AUTHORIZATION_URL=https://accounts.google.com/o/oauth2/v2/auth
+SSO_TOKEN_URL=https://oauth2.googleapis.com/token
+SSO_INTROSPECTION_URL=https://oauth2.googleapis.com/tokeninfo
+SSO_SCOPES=https://www.googleapis.com/auth/userinfo.email,openid,https://www.googleapis.com/auth/userinfo.profile
+SSO_CALLBACK_URL=http://localhost:5001/auth/callback/oidc
+```
+
+Set `SSO_INTROSPECTION_MODE=tokeninfo` so the server validates tokens with `GET ?access_token=...` and normalizes the response to the RFC 7662 `{ "active": true }` shape expected by the auth middleware.
+
+> **Note:** Google's tokeninfo endpoint is intended for development and debugging. For production deployments, prefer an OIDC provider with proper introspection support (Keycloak, Auth0, Okta).
 
 ## Discovery Endpoints
 

--- a/docs/session-status.md
+++ b/docs/session-status.md
@@ -1,0 +1,36 @@
+# Session status (local recovery)
+
+> **Durable wiki:** `~/.local/share/second-brain/wiki/work/template-mcp-server.md`
+> Say **"read second brain template-mcp-server"** in a new Cursor chat to reload context.
+
+Last updated: 2026-08-18
+
+## Open work
+
+| Item | Action |
+|------|--------|
+| [PR #81](https://github.com/redhat-data-and-ai/template-mcp-server/pull/81) | DCO fixed on `deep-agent`; await CI/review |
+| [PR #80](https://github.com/redhat-data-and-ai/template-mcp-server/pull/80) | Awaiting merge to `main` (CI green) |
+| MCP 2026-07-28 migration | Post-merge spike — see wiki; **not** a blocker for #80/#81 |
+
+## Branch map
+
+- `refactor/tools-config-as-code` → `main` (template demo tools)
+- `deep-agent` → `upstream/deep-agent` (BMI, email, web search + OAuth + Makefile fix)
+
+## Quick verify
+
+```bash
+cd ~/github/template-mcp-server
+git checkout deep-agent && git log --oneline -5
+pre-commit run --all-files && make test
+```
+
+## Local MCP
+
+- Server: `http://localhost:5010/mcp` (`~/.cursor/mcp.json` → `template-mcp-server`)
+- Port 5001 is often Presidio, not this server
+
+## MCP 2026 spec
+
+Spec migration (stateless core, header routing) is tracked in second brain [intel/mcp.md](file:///Users/whenry/.local/share/second-brain/wiki/intel/mcp.md). Protocol layer is FastMCP; config-as-code PRs do not need redesign.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,7 @@ build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
 packages = ["template_mcp_server"]
+force-include = { "template_mcp_server/config" = "template_mcp_server/config" }
 
 [project]
 name = "template-mcp-server"
@@ -38,6 +39,7 @@ dependencies = [
     "requests-oauthlib==2.0.0",
     "tavily-python>=0.5.0",
     "resend>=2.6.0",
+    "pyyaml==6.0.2",
 ]
 
 [project.optional-dependencies]

--- a/template_mcp_server/config/tools/README.md
+++ b/template_mcp_server/config/tools/README.md
@@ -1,0 +1,43 @@
+# MCP Tools Config
+
+Tool **surface** (name, description, parameters, agent metadata) lives here as YAML.
+Tool **behavior** lives in `template_mcp_server/src/tools/` as Python handlers.
+
+## Add a tool
+
+1. Create a handler in `src/tools/your_tool.py`.
+2. Copy [`tool_template.yaml.example`](tool_template.yaml.example) to `your_tool.yaml` and edit it (the `.yaml.example` suffix keeps it out of the `*.yaml` loader glob).
+3. Restart the server (no changes to `mcp.py` required).
+
+For a full walkthrough, see [docs/tutorial.md](../../../docs/tutorial.md).
+
+## Example
+
+```yaml
+name: greet_user
+enabled: true
+handler: template_mcp_server.src.tools.greet_tool:greet_user
+display_name: Greet User
+description: Return a greeting for the given name.
+params:
+  - name: name
+    type: string
+    required: true
+    description: Name to greet
+agent:
+  usecase: Generate a friendly greeting
+  instructions: |
+    1. Provide a non-empty name string
+    2. Call the tool
+    3. Receive the greeting
+  input_description: "name (string): person to greet"
+  output_description: Dictionary with status, operation, name, greeting, and message
+  examples:
+    - greet_user("Alice")
+  prerequisites: none
+  related_tools: []
+```
+
+## Override config path
+
+Set `MCP_TOOLS_CONFIG_PATH` to mount an alternate directory (for example an OpenShift ConfigMap).

--- a/template_mcp_server/config/tools/calculate_bmi.yaml
+++ b/template_mcp_server/config/tools/calculate_bmi.yaml
@@ -1,0 +1,28 @@
+name: calculate_bmi
+enabled: true
+handler: template_mcp_server.src.tools.bmi_tool:calculate_bmi
+display_name: BMI Calculator
+description: Calculate Body Mass Index from height and weight using WHO categories.
+params:
+  - name: height
+    type: string
+    required: true
+    description: Height in centimeters (e.g., "175")
+  - name: weight
+    type: string
+    required: true
+    description: Weight in kilograms (e.g., "70.5")
+agent:
+  usecase: Compute BMI and health category from height and weight
+  instructions: |
+    1. Provide height in centimeters as a string
+    2. Provide weight in kilograms as a string
+    3. Receive BMI value and WHO category
+  input_description: 'height (string): cm, weight (string): kg. Example: ("175", "70")'
+  output_description: Dictionary with status, bmi, category, height_cm, weight_kg, and message
+  examples:
+    - calculate_bmi("175", "70")
+    - calculate_bmi("180", "85.5")
+  prerequisites: none
+  related_tools:
+    - validate_email

--- a/template_mcp_server/config/tools/search_web.yaml
+++ b/template_mcp_server/config/tools/search_web.yaml
@@ -1,0 +1,28 @@
+name: search_web
+enabled: true
+handler: template_mcp_server.src.tools.web_search_tool:search_web
+display_name: Web Search
+description: Search the web using the Tavily API with parallel queries and deduplicated results.
+params:
+  - name: queries
+    type: array
+    required: true
+    description: List of search query strings to run in parallel
+  - name: max_results
+    type: integer
+    required: false
+    default: 5
+    description: Maximum results per query (1-10)
+agent:
+  usecase: Find current information from the web for research or fact-checking
+  instructions: |
+    1. Provide one or more search query strings
+    2. Optionally set max_results per query (default 5)
+    3. Receive deduplicated results with title, url, snippet, and score
+  input_description: 'queries (array of strings), max_results (int, optional, default 5)'
+  output_description: Dictionary with status, queries, total_results, results list, and message
+  examples:
+    - search_web(["latest AI news"], 5)
+    - search_web(["Python 3.13 features", "asyncio best practices"])
+  prerequisites: TAVILY_API_KEY configured
+  related_tools: []

--- a/template_mcp_server/config/tools/send_email.yaml
+++ b/template_mcp_server/config/tools/send_email.yaml
@@ -1,0 +1,31 @@
+name: send_email
+enabled: true
+handler: template_mcp_server.src.tools.email_tool:send_email
+display_name: Send Email
+description: Send HTML email via the Resend API.
+params:
+  - name: email_id
+    type: string
+    required: true
+    description: Recipient email address
+  - name: subject
+    type: string
+    required: true
+    description: Email subject line (max 255 characters)
+  - name: body
+    type: string
+    required: true
+    description: HTML body content
+agent:
+  usecase: Send email to a recipient with subject and HTML body
+  instructions: |
+    1. Validate recipient email if needed (validate_email)
+    2. Provide recipient, subject, and HTML body
+    3. Receive delivery status string
+  input_description: "email_id (string), subject (string), body (string, HTML)"
+  output_description: String status message confirming send or describing the error
+  examples:
+    - send_email("user@example.com", "Hello", "<p>Hi there</p>")
+  prerequisites: RESEND_API_KEY configured; optional RESEND_FROM_EMAIL and RESEND_TO_EMAIL
+  related_tools:
+    - validate_email

--- a/template_mcp_server/config/tools/tool_template.yaml.example
+++ b/template_mcp_server/config/tools/tool_template.yaml.example
@@ -1,0 +1,55 @@
+# Copy this file to create a new tool config:
+#   cp tool_template.yaml.example your_tool.yaml
+#
+# Files ending in .yaml.example are NOT loaded (loader globs *.yaml only).
+# See docs/tutorial.md for the full walkthrough.
+
+# MCP tool name — must be unique across all *.yaml files in this directory.
+name: your_tool
+
+# Set false to keep the config on disk without registering at startup.
+enabled: true
+
+# Python handler as module:function (behavior lives in src/tools/).
+handler: template_mcp_server.src.tools.your_tool:your_tool
+
+# Human-friendly label shown in agent metadata.
+display_name: Your Tool
+
+# Short summary for tools/list. Use | or > for longer multiline text.
+description: |
+  One-line summary of what the tool does.
+
+  Optional extra paragraph with more detail for agents and reviewers.
+
+params:
+  # Required parameter
+  - name: input
+    type: string # str, string, float, int, integer, bool, boolean
+    required: true
+    description: Primary input for the tool
+
+  # Optional parameter with default
+  - name: format
+    type: string
+    required: false
+    default: json
+    description: Output format (optional)
+
+agent:
+  usecase: When an agent should choose this tool over others
+
+  instructions: |
+    1. First step for the agent
+    2. Second step
+    3. What to expect back
+
+  input_description: "input (string): required; format (string, optional): default json"
+  output_description: Dictionary with status, operation, result fields, and message
+
+  examples:
+    - your_tool("example")
+    - your_tool("example", format="text")
+
+  prerequisites: none
+  related_tools: [] # names of other tools in this directory, e.g. [multiply_numbers]

--- a/template_mcp_server/config/tools/validate_email.yaml
+++ b/template_mcp_server/config/tools/validate_email.yaml
@@ -1,0 +1,23 @@
+name: validate_email
+enabled: true
+handler: template_mcp_server.src.tools.validate_email_tool:validate_email
+display_name: Email Validator
+description: Validate an email address format and return structured validation feedback.
+params:
+  - name: email
+    type: string
+    required: true
+    description: Email address to validate (e.g., user@example.com)
+agent:
+  usecase: Check whether an email address has a valid format before sending mail
+  instructions: |
+    1. Provide a single email address string
+    2. Receive valid flag, reason, and message
+  input_description: "email (string): address to validate"
+  output_description: Dictionary with status, valid, reason, email, and message
+  examples:
+    - validate_email("user@example.com")
+    - validate_email("not-an-email")
+  prerequisites: none
+  related_tools:
+    - send_email

--- a/template_mcp_server/src/mcp.py
+++ b/template_mcp_server/src/mcp.py
@@ -7,12 +7,7 @@ tools for MCP clients. It uses FastMCP to register and manage MCP capabilities.
 from fastmcp import FastMCP
 
 from template_mcp_server.src.settings import settings
-from template_mcp_server.src.tools.bmi_tool import calculate_bmi
-from template_mcp_server.src.tools.email_tool import (
-    send_email,
-)
-from template_mcp_server.src.tools.validate_email_tool import validate_email
-from template_mcp_server.src.tools.web_search_tool import search_web
+from template_mcp_server.src.tools_loader import load_tool_registry
 from template_mcp_server.utils.pylogger import (
     force_reconfigure_all_loggers,
     get_python_logger,
@@ -46,18 +41,11 @@ class TemplateMCPServer:
             raise
 
     def _register_mcp_tools(self) -> None:
-        """Register MCP tools for template operations (tools-first architecture).
+        """Register MCP tools from config/tools YAML definitions.
 
-        Registers all available tools with the FastMCP server instance.
-        In tools-first architecture, the server only provides tools.
-        Currently includes:
-        - calculate_bmi: BMI calculator
-        - search_web: Web search using Tavily API for current information
-        - send_email: Email operations
-        - validate_email: Email format validation
+        Tools are loaded from YAML config (see template_mcp_server/config/tools/)
+        and wired to Python handlers via explicit handler: module:attr references.
         """
-        # Register all the imported tools
-        self.mcp.tool()(calculate_bmi)
-        self.mcp.tool()(search_web)
-        self.mcp.tool()(send_email)
-        self.mcp.tool()(validate_email)
+        registry = load_tool_registry()
+        for tool_fn in registry.values():
+            self.mcp.tool()(tool_fn)

--- a/template_mcp_server/src/oauth/handler.py
+++ b/template_mcp_server/src/oauth/handler.py
@@ -10,15 +10,13 @@ This module provides OAuth 2.0 authentication functionality including:
 import time
 from typing import Any, Dict, Optional
 
-import httpx
 from requests_oauthlib import OAuth2Session
 
+from template_mcp_server.src.oauth.introspection import create_token_introspector
 from template_mcp_server.src.settings import settings
 from template_mcp_server.utils.pylogger import get_python_logger
 
 logger = get_python_logger()
-
-SCOPE = ["email", "openid", "profile", "session:role-any"]
 
 
 class OAuth2Handler:
@@ -29,7 +27,7 @@ class OAuth2Handler:
         """Create an OAuth2 session with the specified state."""
         return OAuth2Session(
             settings.SSO_CLIENT_ID,
-            scope=SCOPE,
+            scope=settings.oauth_scopes,
             redirect_uri=settings.SSO_CALLBACK_URL,
             state=state,
         )
@@ -69,37 +67,18 @@ class OAuth2Handler:
 
     @staticmethod
     def introspect_token(token: str) -> Dict[str, Any]:
-        """Introspect a token using the configured SSO introspection endpoint."""
-        introspection_url = settings.SSO_INTROSPECTION_URL
-
-        try:
-            response = httpx.post(
-                introspection_url,
-                data={
-                    "token": token,
-                    "client_id": settings.SSO_CLIENT_ID,
-                    "client_secret": settings.SSO_CLIENT_SECRET,
-                },
-                headers={"Content-Type": "application/x-www-form-urlencoded"},
-                timeout=10.0,
-            )
-            response.raise_for_status()
-
-            introspection_data = response.json()
-            logger.debug(f"Token introspection response: {introspection_data}")
-
-            return introspection_data
-
-        except httpx.HTTPError as e:
-            logger.error(f"Token introspection failed: {e}")
-            return {"active": False, "error": f"Introspection failed: {e}"}
-        except Exception as e:
-            logger.error(f"Unexpected error during token introspection: {e}")
-            return {"active": False, "error": f"Unexpected error: {e}"}
+        """Introspect a token using the configured SSO introspection strategy."""
+        introspector = create_token_introspector(
+            settings.SSO_INTROSPECTION_MODE,
+            settings.SSO_INTROSPECTION_URL,
+            settings.SSO_CLIENT_ID,
+            settings.SSO_CLIENT_SECRET,
+        )
+        return introspector.introspect(token)
 
     @staticmethod
     def verify_access_token(token: str) -> Optional[Dict[str, Any]]:
-        """Verify an access token using RedHat's introspection endpoint."""
+        """Verify an access token via the configured SSO introspection endpoint."""
         introspection_result = OAuth2Handler.introspect_token(token)
 
         if not introspection_result.get("active", False):
@@ -108,7 +87,7 @@ class OAuth2Handler:
 
         # Check if token is expired
         exp = introspection_result.get("exp")
-        if exp and exp < time.time():
+        if exp is not None and int(exp) < time.time():
             logger.warning("Token has expired")
             return None
 
@@ -122,7 +101,7 @@ class OAuth2Handler:
 
     @staticmethod
     def verify_authorization_header(auth_header: str) -> Optional[Dict[str, Any]]:
-        """Verify Authorization header with Bearer token using RedHat's introspection."""
+        """Verify Authorization header with Bearer token via SSO introspection."""
         if not auth_header or not auth_header.startswith("Bearer "):
             logger.warning("Invalid authorization header format")
             return None

--- a/template_mcp_server/src/oauth/introspection.py
+++ b/template_mcp_server/src/oauth/introspection.py
@@ -1,0 +1,143 @@
+"""Pluggable token introspection strategies for OAuth SSO providers."""
+
+from abc import ABC, abstractmethod
+from typing import Any, Dict
+
+import httpx
+
+from template_mcp_server.utils.pylogger import get_python_logger
+
+logger = get_python_logger()
+
+INTROSPECTION_MODE_RFC7662 = "rfc7662"
+INTROSPECTION_MODE_TOKENINFO = "tokeninfo"
+SUPPORTED_INTROSPECTION_MODES = frozenset(
+    {INTROSPECTION_MODE_RFC7662, INTROSPECTION_MODE_TOKENINFO}
+)
+
+
+class TokenIntrospector(ABC):
+    """Validate access tokens against a configured SSO introspection endpoint."""
+
+    @abstractmethod
+    def introspect(self, token: str) -> Dict[str, Any]:
+        """Return RFC 7662-like introspection payload with an ``active`` flag."""
+
+
+class Rfc7662Introspector(TokenIntrospector):
+    """RFC 7662 POST introspection (Keycloak, Auth0, Okta, Red Hat SSO, etc.)."""
+
+    def __init__(
+        self,
+        url: str,
+        client_id: str,
+        client_secret: str,
+        timeout: float = 10.0,
+    ) -> None:
+        """Initialize RFC 7662 introspection client settings."""
+        self.url = url
+        self.client_id = client_id
+        self.client_secret = client_secret
+        self.timeout = timeout
+
+    def introspect(self, token: str) -> Dict[str, Any]:
+        """POST the token to the introspection endpoint and return the JSON payload."""
+        try:
+            response = httpx.post(
+                self.url,
+                data={
+                    "token": token,
+                    "client_id": self.client_id,
+                    "client_secret": self.client_secret,
+                },
+                headers={"Content-Type": "application/x-www-form-urlencoded"},
+                timeout=self.timeout,
+            )
+            response.raise_for_status()
+            data = response.json()
+            logger.debug(f"Token introspection response: {data}")
+            return data
+        except httpx.HTTPError as e:
+            logger.error(f"Token introspection failed: {e}")
+            return {"active": False, "error": f"Introspection failed: {e}"}
+        except Exception as e:
+            logger.error(f"Unexpected error during token introspection: {e}")
+            return {"active": False, "error": f"Unexpected error: {e}"}
+
+
+class TokenInfoIntrospector(TokenIntrospector):
+    """GET-based tokeninfo validation for providers without RFC 7662 introspection."""
+
+    def __init__(
+        self,
+        url: str,
+        client_id: str = "",
+        timeout: float = 10.0,
+    ) -> None:
+        """Initialize tokeninfo introspection client settings."""
+        self.url = url
+        self.client_id = client_id
+        self.timeout = timeout
+
+    @staticmethod
+    def normalize_response(data: Dict[str, Any], client_id: str = "") -> Dict[str, Any]:
+        """Map tokeninfo-style payloads to RFC 7662-like shape."""
+        if "active" in data:
+            return data
+
+        if data.get("error"):
+            return {"active": False, **data}
+
+        if "sub" in data or "email" in data:
+            normalized = dict(data)
+            normalized["active"] = True
+            normalized.setdefault("token_type", "Bearer")
+            if "exp" in normalized:
+                normalized["exp"] = int(normalized["exp"])
+
+            aud = normalized.get("aud") or normalized.get("azp")
+            if aud and client_id and aud != client_id:
+                return {
+                    "active": False,
+                    "error": "audience_mismatch",
+                    "aud": aud,
+                }
+
+            return normalized
+
+        return {"active": False, **data}
+
+    def introspect(self, token: str) -> Dict[str, Any]:
+        """Validate the token via tokeninfo and return a normalized payload."""
+        try:
+            response = httpx.get(
+                self.url,
+                params={"access_token": token},
+                timeout=self.timeout,
+            )
+            response.raise_for_status()
+            data = self.normalize_response(response.json(), self.client_id)
+            logger.debug(f"Token introspection response: {data}")
+            return data
+        except httpx.HTTPError as e:
+            logger.error(f"Token introspection failed: {e}")
+            return {"active": False, "error": f"Introspection failed: {e}"}
+        except Exception as e:
+            logger.error(f"Unexpected error during token introspection: {e}")
+            return {"active": False, "error": f"Unexpected error: {e}"}
+
+
+def create_token_introspector(
+    mode: str,
+    url: str,
+    client_id: str,
+    client_secret: str,
+) -> TokenIntrospector:
+    """Build the introspection strategy configured for the current SSO provider."""
+    if mode == INTROSPECTION_MODE_TOKENINFO:
+        return TokenInfoIntrospector(url=url, client_id=client_id)
+    return Rfc7662Introspector(
+        url=url,
+        client_id=client_id,
+        client_secret=client_secret,
+    )

--- a/template_mcp_server/src/settings.py
+++ b/template_mcp_server/src/settings.py
@@ -343,6 +343,17 @@ class Settings(BaseSettings):
             "example": 30.0,
         },
     )
+    MCP_TOOLS_CONFIG_PATH: Optional[str] = Field(
+        default=None,
+        json_schema_extra={
+            "env": "MCP_TOOLS_CONFIG_PATH",
+            "description": (
+                "Optional path to directory of per-tool YAML configs "
+                "(default: template_mcp_server/config/tools)"
+            ),
+            "example": "/etc/mcp/tools",
+        },
+    )
 
 
 def validate_config(settings: Settings) -> None:

--- a/template_mcp_server/src/settings.py
+++ b/template_mcp_server/src/settings.py
@@ -1,9 +1,10 @@
 """Settings for the Template MCP Server."""
 
-from typing import List, Optional
+from functools import cached_property
+from typing import List, Literal, Optional
 
 from dotenv import load_dotenv
-from pydantic import Field
+from pydantic import Field, model_validator
 from pydantic_settings import BaseSettings
 
 from template_mcp_server.utils.pylogger import get_python_logger
@@ -17,6 +18,21 @@ try:
 except Exception as e:
     # Log error but don't fail - environment variables might be set directly
     logger.warning(f"Could not load .env file: {e}")
+
+
+def parse_sso_scopes(sso_scopes: str) -> list[str]:
+    """Parse comma-separated SSO_SCOPES into a list of non-empty scope strings."""
+    raw = sso_scopes or ""
+    return [s.strip() for s in raw.split(",") if s.strip()]
+
+
+def validate_sso_scopes(enable_auth: bool, sso_scopes: str) -> None:
+    """Validate SSO_SCOPES according to auth mode."""
+    if enable_auth and not parse_sso_scopes(sso_scopes):
+        raise ValueError(
+            "SSO_SCOPES must contain at least one OAuth scope when ENABLE_AUTH is True "
+            '(comma-separated, e.g. "email,openid,profile").'
+        )
 
 
 class Settings(BaseSettings):
@@ -161,6 +177,29 @@ class Settings(BaseSettings):
         json_schema_extra={
             "env": "SSO_INTROSPECTION_URL",
             "description": "SSO token introspection endpoint URL",
+        },
+    )
+    SSO_INTROSPECTION_MODE: Literal["rfc7662", "tokeninfo"] = Field(
+        default="rfc7662",
+        json_schema_extra={
+            "env": "SSO_INTROSPECTION_MODE",
+            "description": (
+                "Token validation strategy: rfc7662 (POST introspection) or "
+                "tokeninfo (GET access_token query param for providers like Google)"
+            ),
+            "example": "rfc7662",
+            "enum": ["rfc7662", "tokeninfo"],
+        },
+    )
+    SSO_SCOPES: str = Field(
+        default="email,openid,profile,session:role-any",
+        json_schema_extra={
+            "env": "SSO_SCOPES",
+            "description": (
+                "Comma-separated OAuth scopes to request (e.g. email,openid,profile for Google). "
+                "When ENABLE_AUTH is True, at least one non-empty scope is required."
+            ),
+            "example": "email,openid,profile",
         },
     )
     SESSION_SECRET: Optional[str] = Field(
@@ -355,6 +394,17 @@ class Settings(BaseSettings):
         },
     )
 
+    @model_validator(mode="after")
+    def validate_oauth_scopes(self) -> "Settings":
+        """Validate SSO_SCOPES when auth is enabled."""
+        validate_sso_scopes(self.ENABLE_AUTH, self.SSO_SCOPES)
+        return self
+
+    @cached_property
+    def oauth_scopes(self) -> list[str]:
+        """Oauth scopes derived from SSO_SCOPES (computed once per Settings instance)."""
+        return parse_sso_scopes(self.SSO_SCOPES)
+
 
 def validate_config(settings: Settings) -> None:
     """Validate configuration settings.
@@ -387,6 +437,8 @@ def validate_config(settings: Settings) -> None:
         raise ValueError(
             f"MCP_TRANSPORT_PROTOCOL must be one of {valid_transport_protocols}, got {settings.MCP_TRANSPORT_PROTOCOL}"
         )
+
+    validate_sso_scopes(settings.ENABLE_AUTH, settings.SSO_SCOPES)
 
 
 # Create config instance without validation (validation happens in main.py)

--- a/template_mcp_server/src/tools_loader.py
+++ b/template_mcp_server/src/tools_loader.py
@@ -1,0 +1,265 @@
+"""Load MCP tools from YAML config and build FastMCP-ready callables."""
+
+from __future__ import annotations
+
+import importlib
+import inspect
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any, Type, cast
+
+import yaml
+from pydantic import BaseModel, ConfigDict, Field
+
+from template_mcp_server.utils.pylogger import get_python_logger
+
+logger = get_python_logger()
+
+TYPE_ALIASES: dict[str, type] = {
+    "str": str,
+    "string": str,
+    "float": float,
+    "int": int,
+    "integer": int,
+    "bool": bool,
+    "boolean": bool,
+}
+
+
+class ToolParamConfig(BaseModel):
+    """Schema for a single tool parameter declared in YAML."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    name: str
+    type: str = "str"
+    required: bool = True
+    default: Any = None
+    description: str = ""
+
+    def python_type(self) -> Type[Any]:
+        """Map the YAML type string to a Python type for FastMCP introspection."""
+        normalized = self.type.lower()
+        if normalized in {"list", "array", "list[str]", "array[string]"}:
+            return list[str]
+        return TYPE_ALIASES.get(normalized, str)
+
+
+class AgentMetadata(BaseModel):
+    """Agent-facing metadata for tool discovery and routing."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    usecase: str = ""
+    instructions: str = ""
+    input_description: str = ""
+    output_description: str = ""
+    examples: list[str] = Field(default_factory=list)
+    prerequisites: str = "none"
+    related_tools: list[str] = Field(default_factory=list)
+
+
+class ToolConfig(BaseModel):
+    """Full tool definition loaded from a YAML file."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    name: str
+    enabled: bool = True
+    handler: str
+    display_name: str
+    description: str
+    params: list[ToolParamConfig] = Field(default_factory=list)
+    agent: AgentMetadata = Field(default_factory=AgentMetadata)
+
+
+def default_tools_config_path() -> Path:
+    """Return the default tools config directory bundled with the package."""
+    return Path(__file__).resolve().parent.parent / "config" / "tools"
+
+
+def resolve_tools_config_path(config_path: Path | str | None = None) -> Path:
+    """Resolve the tools config directory from override or settings."""
+    if config_path is not None:
+        return Path(config_path)
+
+    from template_mcp_server.src.settings import settings
+
+    config_override = settings.MCP_TOOLS_CONFIG_PATH
+    if isinstance(config_override, str) and config_override.strip():
+        return Path(config_override)
+
+    return default_tools_config_path()
+
+
+def load_tool_configs(config_path: Path | str | None = None) -> list[ToolConfig]:
+    """Load and validate all tool YAML files from the config directory."""
+    tools_dir = resolve_tools_config_path(config_path)
+    if not tools_dir.is_dir():
+        raise FileNotFoundError(f"Tools config directory not found: {tools_dir}")
+
+    configs: list[ToolConfig] = []
+    seen_names: set[str] = set()
+
+    for yaml_file in sorted(tools_dir.glob("*.yaml")):
+        with yaml_file.open(encoding="utf-8") as handle:
+            data = yaml.safe_load(handle)
+
+        if not data:
+            continue
+
+        config = ToolConfig.model_validate(data)
+        if config.name in seen_names:
+            raise ValueError(f"Duplicate tool name '{config.name}' in {yaml_file}")
+        seen_names.add(config.name)
+        configs.append(config)
+
+    if not configs:
+        raise ValueError(f"No tool configs found in {tools_dir}")
+
+    return configs
+
+
+def import_handler(handler: str) -> Callable[..., Any]:
+    """Import a handler callable from a module:attr string."""
+    module_path, _, attr = handler.partition(":")
+    if not module_path or not attr:
+        raise ValueError(f"Invalid handler '{handler}': expected 'module:attr'")
+
+    module = importlib.import_module(module_path)
+    fn = getattr(module, attr, None)
+    if fn is None or not callable(fn):
+        raise ValueError(f"Handler '{handler}' is not callable")
+    return fn
+
+
+def _format_related_tools(related: list[str]) -> str:
+    if not related:
+        return "None"
+    return ", ".join(related)
+
+
+def build_agent_docstring(config: ToolConfig) -> str:
+    """Build the agent metadata docstring from YAML fields."""
+    agent = config.agent
+    examples = ", ".join(agent.examples) if agent.examples else f"{config.name}()"
+    return "\n".join(
+        [
+            config.description,
+            "",
+            f"TOOL_NAME={config.name}",
+            f"DISPLAY_NAME={config.display_name}",
+            f"USECASE={agent.usecase}",
+            f"INSTRUCTIONS={agent.instructions.strip()}",
+            f"INPUT_DESCRIPTION={agent.input_description}",
+            f"OUTPUT_DESCRIPTION={agent.output_description}",
+            f"EXAMPLES={examples}",
+            f"PREREQUISITES={agent.prerequisites}",
+            f"RELATED_TOOLS={_format_related_tools(agent.related_tools)}",
+        ]
+    )
+
+
+def _build_signature(
+    config: ToolConfig, return_annotation: Any = dict[str, Any]
+) -> inspect.Signature:
+    parameters: list[inspect.Parameter] = []
+    for param in config.params:
+        annotation = param.python_type()
+        if param.required and param.default is None:
+            default = inspect.Parameter.empty
+        else:
+            default = param.default
+        parameters.append(
+            inspect.Parameter(
+                param.name,
+                inspect.Parameter.POSITIONAL_OR_KEYWORD,
+                default=default,
+                annotation=annotation,
+            )
+        )
+    return inspect.Signature(parameters, return_annotation=dict[str, Any])
+
+
+def _bind_and_call(
+    signature: inspect.Signature, handler: Callable[..., Any], *args: Any, **kwargs: Any
+) -> Any:
+    bound = signature.bind_partial(*args, **kwargs)
+    bound.apply_defaults()
+    return handler(**bound.arguments)
+
+
+async def _bind_and_call_async(
+    signature: inspect.Signature, handler: Callable[..., Any], *args: Any, **kwargs: Any
+) -> Any:
+    bound = signature.bind_partial(*args, **kwargs)
+    bound.apply_defaults()
+    return await handler(**bound.arguments)
+
+
+def _apply_wrapper_metadata(
+    wrapper: Callable[..., Any],
+    config: ToolConfig,
+    signature: inspect.Signature,
+    docstring: str,
+    annotations: dict[str, Any],
+) -> Callable[..., Any]:
+    wrapper.__name__ = config.name
+    wrapper.__doc__ = docstring
+    wrapper.__signature__ = signature  # type: ignore[attr-defined]
+    wrapper.__annotations__ = annotations
+    return wrapper
+
+
+def build_tool_callable(
+    config: ToolConfig, handler: Callable[..., Any]
+) -> Callable[..., Any]:
+    """Wrap a handler with YAML-driven name, signature, and docstring."""
+    handler_return = inspect.signature(handler).return_annotation
+    if handler_return is inspect.Parameter.empty:
+        handler_return = dict[str, Any]
+    signature = _build_signature(config, handler_return)
+    docstring = build_agent_docstring(config)
+    annotations = {param.name: param.python_type() for param in config.params}
+    annotations["return"] = handler_return
+
+    if inspect.iscoroutinefunction(handler):
+
+        async def async_wrapper(*args: Any, **kwargs: Any) -> Any:
+            return await _bind_and_call_async(signature, handler, *args, **kwargs)
+
+        return _apply_wrapper_metadata(
+            cast(Callable[..., Any], async_wrapper),
+            config,
+            signature,
+            docstring,
+            annotations,
+        )
+
+    def sync_wrapper(*args: Any, **kwargs: Any) -> Any:
+        return _bind_and_call(signature, handler, *args, **kwargs)
+
+    return _apply_wrapper_metadata(
+        sync_wrapper, config, signature, docstring, annotations
+    )
+
+
+def load_tool_registry(
+    config_path: Path | str | None = None,
+) -> dict[str, Callable[..., Any]]:
+    """Load enabled tools from config and return a name -> callable registry."""
+    registry: dict[str, Callable[..., Any]] = {}
+
+    for config in load_tool_configs(config_path):
+        if not config.enabled:
+            logger.info("Skipping disabled tool: %s", config.name)
+            continue
+
+        handler = import_handler(config.handler)
+        registry[config.name] = build_tool_callable(config, handler)
+        logger.debug("Loaded tool from config: %s", config.name)
+
+    if not registry:
+        raise ValueError("No enabled tools found in configuration")
+
+    return registry

--- a/tests/test_oauth_handler.py
+++ b/tests/test_oauth_handler.py
@@ -3,7 +3,8 @@ from unittest.mock import Mock, patch
 
 import httpx
 
-from template_mcp_server.src.oauth.handler import SCOPE, OAuth2Handler
+from template_mcp_server.src.oauth.handler import OAuth2Handler
+from template_mcp_server.src.settings import Settings, parse_sso_scopes
 
 
 class TestOAuth2Handler:
@@ -14,6 +15,9 @@ class TestOAuth2Handler:
         """Test creating OAuth session without state."""
         mock_settings.SSO_CLIENT_ID = "test_client_id"
         mock_settings.SSO_CALLBACK_URL = "http://localhost:3000/callback"
+        default_scopes = Settings.model_fields["SSO_SCOPES"].default
+        expected_scope = parse_sso_scopes(default_scopes)
+        mock_settings.oauth_scopes = expected_scope
 
         with patch("template_mcp_server.src.oauth.handler.OAuth2Session") as mock_oauth:
             mock_session = Mock()
@@ -23,7 +27,7 @@ class TestOAuth2Handler:
 
             mock_oauth.assert_called_once_with(
                 "test_client_id",
-                scope=SCOPE,
+                scope=expected_scope,
                 redirect_uri="http://localhost:3000/callback",
                 state=None,
             )
@@ -34,6 +38,9 @@ class TestOAuth2Handler:
         """Test creating OAuth session with state."""
         mock_settings.SSO_CLIENT_ID = "test_client_id"
         mock_settings.SSO_CALLBACK_URL = "http://localhost:3000/callback"
+        default_scopes = Settings.model_fields["SSO_SCOPES"].default
+        expected_scope = parse_sso_scopes(default_scopes)
+        mock_settings.oauth_scopes = expected_scope
 
         with patch("template_mcp_server.src.oauth.handler.OAuth2Session") as mock_oauth:
             mock_session = Mock()
@@ -43,7 +50,7 @@ class TestOAuth2Handler:
 
             mock_oauth.assert_called_once_with(
                 "test_client_id",
-                scope=SCOPE,
+                scope=expected_scope,
                 redirect_uri="http://localhost:3000/callback",
                 state="test_state",
             )
@@ -114,11 +121,12 @@ class TestOAuth2Handler:
         assert result == mock_token
 
     @patch("template_mcp_server.src.oauth.handler.settings")
-    @patch("template_mcp_server.src.oauth.handler.httpx.post")
+    @patch("template_mcp_server.src.oauth.introspection.httpx.post")
     def test_introspect_token_success(self, mock_post, mock_settings):
         """Test successful token introspection."""
         mock_settings.SSO_CLIENT_ID = "client123"
         mock_settings.SSO_CLIENT_SECRET = "secret123"
+        mock_settings.SSO_INTROSPECTION_MODE = "rfc7662"
 
         mock_response = Mock()
         mock_response.raise_for_status.return_value = None
@@ -140,7 +148,7 @@ class TestOAuth2Handler:
         assert result == {"active": True, "sub": "user123"}
 
     @patch("template_mcp_server.src.oauth.handler.settings")
-    @patch("template_mcp_server.src.oauth.handler.httpx.post")
+    @patch("template_mcp_server.src.oauth.introspection.httpx.post")
     def test_introspect_token_http_error(self, mock_post, mock_settings):
         """Test token introspection with HTTP error."""
         mock_settings.SSO_CLIENT_ID = "client123"
@@ -154,7 +162,7 @@ class TestOAuth2Handler:
         assert "Introspection failed" in result["error"]
 
     @patch("template_mcp_server.src.oauth.handler.settings")
-    @patch("template_mcp_server.src.oauth.handler.httpx.post")
+    @patch("template_mcp_server.src.oauth.introspection.httpx.post")
     def test_introspect_token_unexpected_error(self, mock_post, mock_settings):
         """Test token introspection with unexpected error."""
         mock_settings.SSO_CLIENT_ID = "client123"
@@ -257,18 +265,13 @@ class TestOAuth2Handler:
         result = OAuth2Handler.verify_authorization_header("Basic token123")
         assert result is None
 
-    def test_scope_constant(self):
-        """Test SCOPE constant is correctly defined."""
-        expected_scope = ["email", "openid", "profile", "session:role-any"]
-        assert SCOPE == expected_scope
-
 
 class TestOAuth2HandlerIntegration:
     """Integration tests for OAuth2Handler."""
 
     @patch("template_mcp_server.src.oauth.handler.settings")
     @patch("template_mcp_server.src.oauth.handler.OAuth2Session")
-    @patch("template_mcp_server.src.oauth.handler.httpx.post")
+    @patch("template_mcp_server.src.oauth.introspection.httpx.post")
     def test_full_oauth_flow_simulation(
         self, mock_post, mock_oauth_session, mock_settings
     ):
@@ -277,6 +280,7 @@ class TestOAuth2HandlerIntegration:
         mock_settings.SSO_CLIENT_ID = "client123"
         mock_settings.SSO_CLIENT_SECRET = "secret123"
         mock_settings.SSO_CALLBACK_URL = "http://localhost:3000/callback"
+        mock_settings.oauth_scopes = ["openid", "email", "profile"]
 
         # Mock OAuth session
         mock_session = Mock()

--- a/tests/test_oauth_introspection.py
+++ b/tests/test_oauth_introspection.py
@@ -1,0 +1,165 @@
+import time
+from unittest.mock import Mock, patch
+
+import httpx
+
+from template_mcp_server.src.oauth.introspection import (
+    Rfc7662Introspector,
+    TokenInfoIntrospector,
+    create_token_introspector,
+)
+
+
+class TestRfc7662Introspector:
+    @patch("template_mcp_server.src.oauth.introspection.httpx.post")
+    def test_introspect_success(self, mock_post):
+        mock_response = Mock()
+        mock_response.raise_for_status.return_value = None
+        mock_response.json.return_value = {"active": True, "sub": "user123"}
+        mock_post.return_value = mock_response
+
+        introspector = Rfc7662Introspector(
+            url="https://sso.example.com/introspect",
+            client_id="client123",
+            client_secret="secret123",
+        )
+        result = introspector.introspect("token123")
+
+        mock_post.assert_called_once_with(
+            "https://sso.example.com/introspect",
+            data={
+                "token": "token123",
+                "client_id": "client123",
+                "client_secret": "secret123",
+            },
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+            timeout=10.0,
+        )
+        assert result == {"active": True, "sub": "user123"}
+
+    @patch("template_mcp_server.src.oauth.introspection.httpx.post")
+    def test_introspect_http_error(self, mock_post):
+        mock_post.side_effect = httpx.HTTPError("Connection failed")
+
+        introspector = Rfc7662Introspector(
+            url="https://sso.example.com/introspect",
+            client_id="client123",
+            client_secret="secret123",
+        )
+        result = introspector.introspect("token123")
+
+        assert result["active"] is False
+        assert "Introspection failed" in result["error"]
+
+
+class TestTokenInfoNormalizeResponse:
+    def test_passthrough_when_active_present(self):
+        data = {"active": False, "sub": "user123"}
+        assert TokenInfoIntrospector.normalize_response(data) == data
+
+    def test_maps_error_to_inactive(self):
+        data = {"error": "invalid_token", "error_description": "Token expired"}
+        result = TokenInfoIntrospector.normalize_response(data)
+        assert result == {"active": False, **data}
+
+    def test_maps_unrecognized_payload_to_inactive(self):
+        data = {"issued_to": "client@apps.googleusercontent.com"}
+        result = TokenInfoIntrospector.normalize_response(data)
+        assert result == {"active": False, **data}
+
+
+class TestTokenInfoIntrospector:
+    @patch("template_mcp_server.src.oauth.introspection.httpx.get")
+    def test_introspect_success(self, mock_get):
+        mock_response = Mock()
+        mock_response.raise_for_status.return_value = None
+        mock_response.json.return_value = {
+            "sub": "123",
+            "email": "user@example.com",
+            "aud": "my-client-id",
+            "exp": str(int(time.time()) + 3600),
+        }
+        mock_get.return_value = mock_response
+
+        introspector = TokenInfoIntrospector(
+            url="https://oauth2.googleapis.com/tokeninfo",
+            client_id="my-client-id",
+        )
+        result = introspector.introspect("ya29.test")
+
+        mock_get.assert_called_once_with(
+            "https://oauth2.googleapis.com/tokeninfo",
+            params={"access_token": "ya29.test"},
+            timeout=10.0,
+        )
+        assert result["active"] is True
+        assert result["sub"] == "123"
+        assert isinstance(result["exp"], int)
+
+    @patch("template_mcp_server.src.oauth.introspection.httpx.get")
+    def test_introspect_audience_mismatch(self, mock_get):
+        mock_response = Mock()
+        mock_response.raise_for_status.return_value = None
+        mock_response.json.return_value = {
+            "sub": "123",
+            "email": "user@example.com",
+            "aud": "other-client-id",
+            "exp": str(int(time.time()) + 3600),
+        }
+        mock_get.return_value = mock_response
+
+        introspector = TokenInfoIntrospector(
+            url="https://oauth2.googleapis.com/tokeninfo",
+            client_id="expected-client-id",
+        )
+        result = introspector.introspect("ya29.test")
+
+        assert result["active"] is False
+        assert result["error"] == "audience_mismatch"
+
+    @patch("template_mcp_server.src.oauth.introspection.httpx.get")
+    def test_introspect_http_error(self, mock_get):
+        mock_get.side_effect = httpx.HTTPError("400 Bad Request")
+
+        introspector = TokenInfoIntrospector(
+            url="https://oauth2.googleapis.com/tokeninfo",
+        )
+        result = introspector.introspect("bad-token")
+
+        assert result["active"] is False
+        assert "Introspection failed" in result["error"]
+
+    @patch("template_mcp_server.src.oauth.introspection.httpx.get")
+    def test_introspect_unexpected_error(self, mock_get):
+        mock_response = Mock()
+        mock_response.raise_for_status.return_value = None
+        mock_response.json.side_effect = ValueError("invalid json")
+        mock_get.return_value = mock_response
+
+        introspector = TokenInfoIntrospector(
+            url="https://oauth2.googleapis.com/tokeninfo",
+        )
+        result = introspector.introspect("ya29.test")
+
+        assert result["active"] is False
+        assert "Unexpected error" in result["error"]
+
+
+class TestCreateTokenIntrospector:
+    def test_create_rfc7662_introspector(self):
+        introspector = create_token_introspector(
+            "rfc7662",
+            "https://sso.example.com/introspect",
+            "client-id",
+            "client-secret",
+        )
+        assert isinstance(introspector, Rfc7662Introspector)
+
+    def test_create_tokeninfo_introspector(self):
+        introspector = create_token_introspector(
+            "tokeninfo",
+            "https://oauth2.googleapis.com/tokeninfo",
+            "client-id",
+            "client-secret",
+        )
+        assert isinstance(introspector, TokenInfoIntrospector)

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -4,8 +4,9 @@ import os
 from unittest.mock import patch
 
 import pytest
+from pydantic import ValidationError
 
-from template_mcp_server.src.settings import Settings, validate_config
+from template_mcp_server.src.settings import Settings, parse_sso_scopes, validate_config
 
 
 class TestSettings:
@@ -87,6 +88,53 @@ class TestSettings:
         assert hasattr(settings, "MCP_TRANSPORT_PROTOCOL")
         assert hasattr(settings, "PYTHON_LOG_LEVEL")
 
+    def test_parse_sso_scopes(self):
+        """Comma-separated scopes strip whitespace and skip empties."""
+        assert parse_sso_scopes("email, openid , profile") == [
+            "email",
+            "openid",
+            "profile",
+        ]
+        assert parse_sso_scopes("") == []
+        assert parse_sso_scopes("  ,  , ") == []
+
+    def test_oauth_scopes_default(self):
+        """oauth_scopes matches SSO_SCOPES when set to the field default."""
+        default = Settings.model_fields["SSO_SCOPES"].default
+        with patch.dict(os.environ, {"SSO_SCOPES": default}):
+            settings = Settings()
+        assert settings.oauth_scopes == parse_sso_scopes(default)
+
+    def test_oauth_scopes_from_env(self):
+        """oauth_scopes reflects SSO_SCOPES from environment."""
+        with patch.dict(os.environ, {"SSO_SCOPES": "a,b,c"}):
+            settings = Settings()
+        assert settings.oauth_scopes == ["a", "b", "c"]
+
+    def test_oauth_scopes_cached_per_instance(self):
+        """oauth_scopes is computed once per Settings instance."""
+        default = Settings.model_fields["SSO_SCOPES"].default
+        with patch.dict(os.environ, {"SSO_SCOPES": default}):
+            settings = Settings()
+        first = settings.oauth_scopes
+        second = settings.oauth_scopes
+        assert first is second
+
+    def test_model_validator_rejects_empty_scopes_when_auth_enabled(self):
+        """Settings init fails if auth is enabled with empty SSO_SCOPES."""
+        with patch.dict(os.environ, {"ENABLE_AUTH": "true", "SSO_SCOPES": ""}):
+            with pytest.raises(
+                ValidationError, match="SSO_SCOPES must contain at least one"
+            ):
+                Settings()
+
+    def test_model_validator_allows_empty_scopes_when_auth_disabled(self):
+        """Settings init allows empty SSO_SCOPES when auth is disabled."""
+        with patch.dict(os.environ, {"ENABLE_AUTH": "false", "SSO_SCOPES": ""}):
+            settings = Settings()
+        assert settings.ENABLE_AUTH is False
+        assert settings.oauth_scopes == []
+
 
 class TestValidateConfig:
     """Test the validate_config function."""
@@ -161,3 +209,26 @@ class TestValidateConfig:
             settings = Settings()
             settings.MCP_TRANSPORT_PROTOCOL = protocol
             validate_config(settings)  # Should not raise
+
+    def test_sso_scopes_empty_when_auth_enabled(self):
+        """Empty SSO_SCOPES fails validation when ENABLE_AUTH is True."""
+        settings = Settings()
+        settings.ENABLE_AUTH = True
+        settings.SSO_SCOPES = ""
+        with pytest.raises(ValueError, match="SSO_SCOPES must contain at least one"):
+            validate_config(settings)
+
+    def test_sso_scopes_whitespace_only_when_auth_enabled(self):
+        """Whitespace-only SSO_SCOPES fails validation when ENABLE_AUTH is True."""
+        settings = Settings()
+        settings.ENABLE_AUTH = True
+        settings.SSO_SCOPES = "  ,  ,  "
+        with pytest.raises(ValueError, match="SSO_SCOPES must contain at least one"):
+            validate_config(settings)
+
+    def test_sso_scopes_empty_when_auth_disabled(self):
+        """Empty SSO_SCOPES is allowed when ENABLE_AUTH is False."""
+        settings = Settings()
+        settings.ENABLE_AUTH = False
+        settings.SSO_SCOPES = ""
+        validate_config(settings)

--- a/tests/test_tools_loader.py
+++ b/tests/test_tools_loader.py
@@ -1,0 +1,193 @@
+"""Tests for the tools config loader."""
+
+import inspect
+from pathlib import Path
+
+import pytest
+
+from template_mcp_server.src import settings as settings_module
+from template_mcp_server.src.tools_loader import (
+    AgentMetadata,
+    ToolConfig,
+    build_agent_docstring,
+    build_tool_callable,
+    default_tools_config_path,
+    import_handler,
+    load_tool_configs,
+    load_tool_registry,
+    resolve_tools_config_path,
+)
+
+DEEP_AGENT_TOOLS = {
+    "calculate_bmi",
+    "validate_email",
+    "send_email",
+    "search_web",
+}
+
+
+class TestToolsLoader:
+    """Test YAML-driven tool loading and registration."""
+
+    def test_default_tools_config_path_exists(self):
+        path = default_tools_config_path()
+        assert path.is_dir()
+        assert list(path.glob("*.yaml"))
+
+    def test_load_tool_configs_returns_four_tools(self):
+        configs = load_tool_configs()
+        names = {config.name for config in configs}
+        assert names == DEEP_AGENT_TOOLS
+
+    def test_load_tool_registry_registers_enabled_tools(self):
+        registry = load_tool_registry()
+        assert set(registry) == DEEP_AGENT_TOOLS
+
+    def test_registry_callable_has_yaml_docstring_metadata(self):
+        registry = load_tool_registry()
+        bmi = registry["calculate_bmi"]
+        assert bmi.__name__ == "calculate_bmi"
+        assert "TOOL_NAME=calculate_bmi" in bmi.__doc__
+        assert "DISPLAY_NAME=BMI Calculator" in bmi.__doc__
+
+    def test_registry_bmi_wrapper_delegates_to_handler(self):
+        registry = load_tool_registry()
+        result = registry["calculate_bmi"](height="175", weight="70")
+        assert result["status"] == "success"
+        assert result["bmi"] > 0
+
+    def test_registry_signature_from_yaml(self):
+        registry = load_tool_registry()
+        sig = inspect.signature(registry["calculate_bmi"])
+        assert list(sig.parameters) == ["height", "weight"]
+        assert sig.parameters["height"].annotation is str
+
+    def test_registry_search_web_signature_includes_list_param(self):
+        registry = load_tool_registry()
+        sig = inspect.signature(registry["search_web"])
+        assert list(sig.parameters) == ["queries", "max_results"]
+        assert sig.parameters["queries"].annotation == list[str]
+
+    def test_import_handler_invalid_format_raises(self):
+        with pytest.raises(ValueError, match="expected 'module:attr'"):
+            import_handler("not_a_valid_handler")
+
+    def test_import_handler_missing_callable_raises(self):
+        with pytest.raises(ValueError, match="is not callable"):
+            import_handler("template_mcp_server.src.tools.bmi_tool:missing_fn")
+
+    def test_load_tool_configs_missing_directory_raises(self, tmp_path: Path):
+        with pytest.raises(FileNotFoundError, match="Tools config directory not found"):
+            load_tool_configs(tmp_path / "missing")
+
+    def test_load_tool_configs_duplicate_names_raises(self, tmp_path: Path):
+        tools_dir = tmp_path / "tools"
+        tools_dir.mkdir()
+        (tools_dir / "one.yaml").write_text(
+            "name: dup\nenabled: true\nhandler: x:y\ndisplay_name: A\ndescription: A\n"
+        )
+        (tools_dir / "two.yaml").write_text(
+            "name: dup\nenabled: true\nhandler: x:y\ndisplay_name: B\ndescription: B\n"
+        )
+        with pytest.raises(ValueError, match="Duplicate tool name"):
+            load_tool_configs(tools_dir)
+
+    def test_load_tool_registry_skips_disabled_tools(self, tmp_path: Path):
+        tools_dir = tmp_path / "tools"
+        tools_dir.mkdir()
+        (tools_dir / "calculate_bmi.yaml").write_text(
+            (default_tools_config_path() / "calculate_bmi.yaml").read_text()
+        )
+        (tools_dir / "disabled.yaml").write_text(
+            "name: disabled_tool\nenabled: false\n"
+            "handler: template_mcp_server.src.tools.bmi_tool:calculate_bmi\n"
+            "display_name: Disabled\ndescription: Disabled tool\n"
+        )
+        registry = load_tool_registry(tools_dir)
+        assert set(registry) == {"calculate_bmi"}
+
+    def test_build_agent_docstring_includes_examples(self):
+        configs = load_tool_configs()
+        bmi = next(c for c in configs if c.name == "calculate_bmi")
+        doc = build_agent_docstring(bmi)
+        assert 'calculate_bmi("175", "70")' in doc
+
+    @pytest.mark.asyncio
+    async def test_async_handler_wrapper_is_coroutine_function(self):
+        configs = load_tool_configs()
+        search_config = next(c for c in configs if c.name == "search_web")
+        handler = import_handler(search_config.handler)
+        wrapped = build_tool_callable(search_config, handler)
+        assert inspect.iscoroutinefunction(wrapped)
+
+    @pytest.mark.asyncio
+    async def test_async_handler_wrapper_delegates_to_handler(self):
+        registry = load_tool_registry()
+        result = await registry["search_web"](queries=["test query"], max_results=1)
+        assert result["status"] == "error"
+        assert "TAVILY_API_KEY" in result["error"]
+
+    def test_resolve_tools_config_path_uses_settings_override(
+        self, tmp_path: Path, monkeypatch
+    ):
+        tools_dir = tmp_path / "custom_tools"
+        tools_dir.mkdir()
+        (tools_dir / "calculate_bmi.yaml").write_text(
+            (default_tools_config_path() / "calculate_bmi.yaml").read_text()
+        )
+        monkeypatch.setattr(
+            settings_module.settings, "MCP_TOOLS_CONFIG_PATH", str(tools_dir)
+        )
+        assert resolve_tools_config_path() == tools_dir
+
+    def test_load_tool_configs_skips_empty_yaml_files(self, tmp_path: Path):
+        tools_dir = tmp_path / "tools"
+        tools_dir.mkdir()
+        (tools_dir / "empty.yaml").write_text("")
+        (tools_dir / "calculate_bmi.yaml").write_text(
+            (default_tools_config_path() / "calculate_bmi.yaml").read_text()
+        )
+        configs = load_tool_configs(tools_dir)
+        assert len(configs) == 1
+        assert configs[0].name == "calculate_bmi"
+
+    def test_load_tool_configs_raises_when_no_valid_configs(self, tmp_path: Path):
+        tools_dir = tmp_path / "tools"
+        tools_dir.mkdir()
+        (tools_dir / "empty.yaml").write_text("")
+        with pytest.raises(ValueError, match="No tool configs found"):
+            load_tool_configs(tools_dir)
+
+    def test_load_tool_registry_raises_when_all_tools_disabled(self, tmp_path: Path):
+        tools_dir = tmp_path / "tools"
+        tools_dir.mkdir()
+        (tools_dir / "disabled.yaml").write_text(
+            "name: disabled_tool\nenabled: false\n"
+            "handler: template_mcp_server.src.tools.bmi_tool:calculate_bmi\n"
+            "display_name: Disabled\ndescription: Disabled tool\n"
+        )
+        with pytest.raises(ValueError, match="No enabled tools found"):
+            load_tool_registry(tools_dir)
+
+    def test_load_tool_configs_rejects_unknown_yaml_fields(self, tmp_path: Path):
+        tools_dir = tmp_path / "tools"
+        tools_dir.mkdir()
+        (tools_dir / "bad.yaml").write_text(
+            "name: bad_tool\nenabled: true\n"
+            "handler: template_mcp_server.src.tools.bmi_tool:calculate_bmi\n"
+            "display_name: Bad\ndescription: Bad tool\n"
+            "typo_field: oops\n"
+        )
+        with pytest.raises(Exception, match="extra_forbidden|Extra inputs"):
+            load_tool_configs(tools_dir)
+
+    def test_build_agent_docstring_formats_related_tools(self):
+        config = ToolConfig(
+            name="example",
+            handler="x:y",
+            display_name="Example",
+            description="Example tool",
+            agent=AgentMetadata(related_tools=["calculate_bmi", "search_web"]),
+        )
+        doc = build_agent_docstring(config)
+        assert "RELATED_TOOLS=calculate_bmi, search_web" in doc


### PR DESCRIPTION
## Summary
- Add `tools_loader` and registry-driven FastMCP registration so tool surface (name, params, agent metadata) lives in YAML under `config/tools/`
- Add YAML configs for all deep-agent tools: `calculate_bmi`, `validate_email`, `send_email`, `search_web`
- Preserve Tavily and Resend settings; add optional `MCP_TOOLS_CONFIG_PATH` override
- Include `tool_template.yaml.example`, loader tests, and PyYAML packaging

## Test plan
- [x] `pre-commit run --all-files`
- [x] `make test` — 280 passed
- [x] `make coverage` — 80.21% (meets 80% threshold)
- [x] `tests/test_tools_loader.py` — 21 passed; `tools_loader.py` at 99% coverage
- [x] Smoke: `load_tool_registry()` returns all 4 deep-agent tools


Made with [Cursor](https://cursor.com)